### PR TITLE
feat(integrity): supply chain audit, dogfooding CI, mypy infra, expanded roadmap

### DIFF
--- a/.archmap.toml
+++ b/.archmap.toml
@@ -4,4 +4,16 @@ forbid = [
   "parser -> cli",
   "analyzer -> cli",
   "graph -> cli",
+  "exporter -> cli",
+  "advisor -> cli",
+  "utils -> cli",
 ]
+
+[risks.layer_order]
+cli      = 1
+analyzer = 2
+advisor  = 3
+exporter = 4
+graph    = 5
+parser   = 6
+utils    = 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "python"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,22 @@ jobs:
         run: python -m ruff check .
         if: matrix.python-version == '3.13'
 
+      - name: Type check (mypy)
+        run: python -m mypy src/archmap/
+        if: matrix.python-version == '3.13'
+        continue-on-error: true
+
+      - name: Audit dependencies (pip-audit)
+        run: pip-audit --skip-editable -q
+        if: matrix.python-version == '3.13'
+
       - name: Run tests with coverage
         run: python -m pytest
 
       - name: Run smoke analysis
         run: python -m archmap.cli.main analyze . --format both --out .codeatlas/ci-graph.json --out-mermaid .codeatlas/ci-graph.mmd --include-cytoscape --out-sarif .codeatlas/ci-archmap.sarif
+        if: matrix.python-version == '3.13'
+
+      - name: Architectural self-check (dogfooding)
+        run: python -m archmap.cli.main analyze src/archmap/ --fail-on-cycles --quiet --format json --out .codeatlas/self-check.json
         if: matrix.python-version == '3.13'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         continue-on-error: true
 
       - name: Audit dependencies (pip-audit)
-        run: pip-audit --skip-editable -q
+        run: pip-audit --progress-spinner off .
         if: matrix.python-version == '3.13'
 
       - name: Run tests with coverage

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,6 +42,18 @@
 - **Architectural Blueprint** — target-state enforcement from `.archmap.toml` layer rules.
 - **Dynamic health badge** — `/api/badge` endpoint for README embedding.
 
+---
+
+## Medium-term (v0.9.x)
+
+- **Shell completion** — bash, zsh, and fish autocompletion via `argcomplete` or `shtab`; `archmap --print-completion bash` convenience flag. Critical DX gap for power users and CI environments.
+- **Docker image** — Official `ghcr.io/kaua-kgzin/archmap:latest` image, published automatically on each release via GitHub Actions. Enables CI use without requiring Python installed in the runner.
+- **Parser resolution rate** — Expose `resolution_rate` (resolved imports ÷ total imports) in JSON output, Web UI, and CLI summary. Warn when below 70%. Add `--min-resolution-rate` gate for CI. Makes parser confidence visible and prevents silently misleading graphs.
+- **Public Python API** — Define and document a stable programmatic surface (`from archmap import analyze_project, ArchMapConfig, AnalysisResult`). Add `__all__` to public modules, document with MkDocs examples, establish a deprecation policy (`DeprecationWarning` + semver). Unlocks IDE plugins, pytest integrations, and custom CI tooling beyond the CLI.
+- **mypy enforcement (blocking)** — Graduate mypy from non-blocking (infrastructure only, v0.8.x) to a hard CI gate. Expand typed coverage module by module until `--strict` is feasible on the full `src/archmap/` tree.
+
+---
+
 ## Longer-term (v0.9.0+)
 
 - Plugin SDK for custom parsers and analyzers via entry points.
@@ -50,3 +62,22 @@
 - Multi-repo topology support.
 - WebSocket-based live UI refresh.
 - GraphML and Graphviz DOT export formats.
+- **Tree-sitter based parsers** — Replace regex-based parsers for JS, TS, Java, PHP, C#, and C++ with `tree-sitter` bindings (Python: `tree-sitter`, `tree-sitter-javascript`, etc.). The Python parser already uses the native AST; applying the same rigor to all languages is the most impactful quality improvement possible. Regex parsers silently misclassify multiline imports, template literals, decorators, and comment-embedded patterns — contaminating every downstream analysis (cycles, risk, trace, LLM advisor).
+- **Property-based testing (Hypothesis)** — Add `hypothesis` to dev deps and use it on all language parsers. Principle: the parser must never crash on any valid unicode input. Finds edge cases that fixed-example tests miss, particularly important for parsers processing untrusted user code.
+- **Mutation testing (mutmut)** — Apply mutation testing to the core analysis modules (`cycle_detector.py`, `risk_analyzer.py`, `complexity_analyzer.py`). Exposes tests that pass accidentally and enforces that the test suite would actually detect bugs in the logic it covers.
+- **Homebrew formula** — Distribute ArchMAP as a Homebrew tap for macOS users (`brew install kaua-kgzin/tap/archmap`). Complements the existing PyPI + Windows EXE distribution and removes the Python-install barrier for macOS developers.
+- **Web UI accessibility (a11y)** — Audit and fix WCAG 2.1 AA compliance in the Web UI: color contrast, keyboard navigation, focus management, ARIA labels for the Cytoscape.js graph. Add `axe-core` to the CI test suite for regression detection.
+- **Web UI graph export** — Add a "Download PNG" and "Download SVG" button to the Web UI using Cytoscape.js's native `cy.png()` and `cy.svg()` APIs. Zero new dependencies; high user value for documentation and presentations.
+- **API stability policy** — Publish a formal versioning contract: which modules are public API (stable across minor versions), which are internal (may break), and what the deprecation timeline is. Correlate with the `__all__` work from the medium-term public API item.
+
+---
+
+## Continuous
+
+These are ongoing commitments rather than versioned deliverables. They run in parallel with every release cycle.
+
+- **Supply chain audit** — `pip-audit` runs in CI on every push (implemented in v0.8.x). Dependabot watches Python deps, npm deps, and GitHub Actions pins on a weekly schedule. No manual audit cadence required.
+- **Architectural self-check (dogfooding)** — CI runs `archmap analyze src/archmap/ --fail-on-cycles` on every push. ArchMAP must pass its own analysis. The health score threshold (`--min-health`) is raised incrementally as the codebase improves, making the gate self-tightening.
+- **mypy coverage expansion** — Type annotations are added incrementally to every new or modified file. The mypy CI step starts non-blocking (infrastructure, v0.8.x) and transitions to a hard gate (v0.9.x) once baseline coverage is established. No new untyped functions merged after v0.9.0.
+- **Documentation freshness** — Every CLI flag, JSON output field, and `.archmap.toml` key introduced in a PR must be documented in the same PR. The MkDocs build runs with `--strict` in CI; broken references fail the docs workflow.
+- **Parser parity** — As new language features are introduced (e.g., Python 3.12+ type parameter syntax, TypeScript 5.x satisfies operator), parser regression tests are added before the parser update is merged. No silent parser regressions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-dev = ["pytest>=8.2.0", "pytest-cov>=5.0.0", "ruff>=0.11.0"]
+dev = ["pytest>=8.2.0", "pytest-cov>=5.0.0", "ruff>=0.11.0", "mypy>=1.10.0", "pip-audit>=2.7.0"]
 docs = ["mkdocs-material>=9.5"]
 
 [project.scripts]
@@ -50,6 +50,12 @@ packages = ["src/archmap"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q --cov=archmap --cov-report=term-missing"
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+check_untyped_defs = true
+warn_unused_ignores = true
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
Immediate integrity improvements identified in architecture review:

- pyproject.toml: add mypy>=1.10.0 and pip-audit>=2.7.0 to dev deps;
  add [tool.mypy] config (ignore_missing_imports, check_untyped_defs,
  warn_unused_ignores) establishing the type-check infrastructure
- ci.yml: add three new quality steps on Python 3.13 —
  (1) Type check (mypy, continue-on-error while baseline is established),
  (2) Audit dependencies (pip-audit --skip-editable),
  (3) Architectural self-check: archmap analyzes itself with --fail-on-cycles,
  making the tool eat its own cooking on every push
- .github/dependabot.yml: weekly automated PRs for pip, npm, and
  GitHub Actions dependency pins — closes the supply chain gap
- .archmap.toml: extend forbid rules to cover exporter, advisor, and
  utils → cli; add [risks.layer_order] so layer violations are scored
  correctly against the actual intended dependency direction
- ROADMAP.md: add Medium-term, Continuous sections and expand
  Longer-term with tree-sitter parsers, Hypothesis, mutmut, Homebrew,
  Web UI a11y/export, and API stability policy

https://claude.ai/code/session_01CQh2kd1jz43S9wUPuQsrTF