### PR TITLE
docs: sync CHANGELOG, analyze docs, and ROADMAP to post-v0.9.0 state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Per-import unresolved tracking** — parser now resolves each import statement individually. `importsTotal`, `importsResolved`, and `unresolvedImports` fields on every `ParsedFile`. `metrics.unresolvedImports` and `metrics.unresolvedImportsTotal` in the graph report.
+- **`--show-unresolved[=N]`** — prints a detailed list of import statements that could not be resolved (file + specifier). `N` controls how many are shown (default 20 when flag is present).
+- **`--fail-on-budget-violations`** — CI gate that exits with code 2 when any file exceeds coupling budgets. Works with CLI overrides or `.archmap.toml`.
+- **`--max-outgoing-per-file N`** — CLI override for maximum allowed outgoing dependencies per file.
+- **`--max-incoming-per-file N`** — CLI override for maximum allowed incoming dependencies per file.
+- **`[analysis.budgets]` in `.archmap.toml`** — `max_outgoing_per_file` and `max_incoming_per_file` config keys for project-wide coupling limits.
+- **`--ignore-external`** — strips external package nodes (e.g. `pkg:requests`) and their edges from the output graph. Metrics are recomputed after filtering. Useful for focusing on internal structure only.
+- **`--summary-format {text,table,markdown}`** — controls the terminal summary output style. `text` (default) is the existing `[ok]/[warn]` format; `table` renders an aligned ASCII table with separator lines; `markdown` renders a pipe-delimited markdown table for pasting into docs or PRs.
+
+### Fixed
+- **SVG injection in `/api/badge`** — health grade string is now XML-escaped via `xml.sax.saxutils.escape` before being embedded in the SVG response. Prevents XSS if a grade value ever contained `<`, `>`, or `&`.
+- **Web UI Config navigation** — Config panel is now accessible via a dedicated gear-icon button in the nav rail (`navBtnConfig`). The ArchMAP logo click is restored to its original behavior: navigating to the Graph view. Previously the logo opened Config, leaving no dedicated button and no way to return to the graph.
+- **`_VALID_LLM_PROVIDERS` scoping in `server.py`** — moved to module-level `frozenset` constant; previously re-declared as a local variable inside `_handle_advise` on every request.
+
 ## [0.9.0] - 2026-05-08
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,11 +2,20 @@
 
 ## Released
 
-### v0.9.0 (current)
+### post-v0.9.0 (main — unreleased)
+- **Per-import unresolved tracking** — `importsTotal`, `importsResolved`, `unresolvedImports` per file; `metrics.unresolvedImports` in graph report.
+- **`--show-unresolved[=N]`** — list imports that failed to resolve (file + specifier).
+- **Coupling budgets** — `[analysis.budgets]` in `.archmap.toml` + `--fail-on-budget-violations` CI gate + `--max-outgoing-per-file` / `--max-incoming-per-file` CLI overrides.
+- **`--ignore-external`** — strip external package nodes and their edges; metrics recomputed on the filtered graph.
+- **`--summary-format {text,table,markdown}`** — flexible terminal summary output.
+- **SVG XSS fix** — health grade XML-escaped in `/api/badge` response.
+- **Web UI** — dedicated gear-icon Config button; logo restored to Graph view navigation.
+
+### v0.9.0
 - **Parser resolution rate** — `resolutionRate` metric in all reports. CLI warns when < 70%. `--min-resolution-rate PCT` gate for CI.
 - **Shell completion** — `archmap --print-completion bash|zsh|fish`. Install: `pip install archmap[completion]`.
-- **Web UI PNG export** — Download button in canvas toolbar, 2× scale, zero deps.
-- **Docker image** — `ghcr.io/kaua-kgzin/archmap:latest` published automatically on each release via GitHub Actions.
+- **Web UI PNG export** — Download button in canvas toolbar, 2× scale, zero deps. ✅
+- **Docker image** — `ghcr.io/kaua-kgzin/archmap:latest` published automatically on each release via GitHub Actions. ✅
 - **i18n — 6 languages** — English, Português (Brasil), Español, Français, Deutsch, 中文 (简体). Instant switch, persisted.
 - **Config panel** — Interface/General/Graph/LLM Advisor/Scan Languages. All persisted in localStorage.
 - **LLM config persistence** — Provider, model, base URL, API key saved; auto-save mode.
@@ -59,29 +68,26 @@
 
 ## Medium-term (v0.9.x)
 
-- **Shell completion** — ✅ Done in v0.9.0.
-- **Docker image** — ✅ Done in v0.8.2.
-- **Parser resolution rate** — ✅ Done in v0.9.0.
 - **Public Python API** — Define and document a stable programmatic surface (`from archmap import analyze_project, ArchMapConfig, AnalysisResult`). Add `__all__` to public modules, document with MkDocs examples, establish a deprecation policy (`DeprecationWarning` + semver). Unlocks IDE plugins, pytest integrations, and custom CI tooling beyond the CLI.
 - **mypy enforcement (blocking)** — Graduate mypy from non-blocking (infrastructure only, v0.8.x) to a hard CI gate. Expand typed coverage module by module until `--strict` is feasible on the full `src/archmap/` tree.
+- **Version bump to v1.0.0** — Finalize the public API contract, write a migration guide from 0.x, and tag the first stable release.
 
 ---
 
-## Longer-term (v0.9.0+)
+## Longer-term
 
 - Plugin SDK for custom parsers and analyzers via entry points.
 - Change coupling detector via `git log` analysis.
-- Complexity budget enforcement per module.
 - Multi-repo topology support.
 - WebSocket-based live UI refresh.
 - GraphML and Graphviz DOT export formats.
-- **Tree-sitter based parsers** — Replace regex-based parsers for JS, TS, Java, PHP, C#, and C++ with `tree-sitter` bindings (Python: `tree-sitter`, `tree-sitter-javascript`, etc.). The Python parser already uses the native AST; applying the same rigor to all languages is the most impactful quality improvement possible. Regex parsers silently misclassify multiline imports, template literals, decorators, and comment-embedded patterns — contaminating every downstream analysis (cycles, risk, trace, LLM advisor).
-- **Property-based testing (Hypothesis)** — Add `hypothesis` to dev deps and use it on all language parsers. Principle: the parser must never crash on any valid unicode input. Finds edge cases that fixed-example tests miss, particularly important for parsers processing untrusted user code.
-- **Mutation testing (mutmut)** — Apply mutation testing to the core analysis modules (`cycle_detector.py`, `risk_analyzer.py`, `complexity_analyzer.py`). Exposes tests that pass accidentally and enforces that the test suite would actually detect bugs in the logic it covers.
-- **Homebrew formula** — Distribute ArchMAP as a Homebrew tap for macOS users (`brew install kaua-kgzin/tap/archmap`). Complements the existing PyPI + Windows EXE distribution and removes the Python-install barrier for macOS developers.
-- **Web UI accessibility (a11y)** — Audit and fix WCAG 2.1 AA compliance in the Web UI: color contrast, keyboard navigation, focus management, ARIA labels for the Cytoscape.js graph. Add `axe-core` to the CI test suite for regression detection.
-- **Web UI graph export** — Add a "Download PNG" and "Download SVG" button to the Web UI using Cytoscape.js's native `cy.png()` and `cy.svg()` APIs. Zero new dependencies; high user value for documentation and presentations.
-- **API stability policy** — Publish a formal versioning contract: which modules are public API (stable across minor versions), which are internal (may break), and what the deprecation timeline is. Correlate with the `__all__` work from the medium-term public API item.
+- **Tree-sitter based parsers** — Replace regex-based parsers for JS, TS, Java, PHP, C#, and C++ with `tree-sitter` bindings. The Python parser already uses the native AST; applying the same rigor to all languages eliminates silent misclassification of multiline imports, template literals, decorators, and comment-embedded patterns.
+- **Property-based testing (Hypothesis)** — Add `hypothesis` to dev deps and use it on all language parsers. The parser must never crash on any valid unicode input.
+- **Mutation testing (mutmut)** — Apply mutation testing to core analysis modules (`cycle_detector.py`, `risk_analyzer.py`, `complexity_analyzer.py`).
+- **Homebrew formula** — Distribute as a Homebrew tap for macOS users (`brew install kaua-kgzin/tap/archmap`).
+- **Web UI accessibility (a11y)** — Audit and fix WCAG 2.1 AA compliance: color contrast, keyboard navigation, focus management, ARIA labels for the Cytoscape.js graph.
+- **SVG export** — Add a "Download SVG" button using Cytoscape.js's `cy.svg()` API.
+- **API stability policy** — Publish a formal versioning contract: public vs. internal modules, deprecation timeline.
 
 ---
 

--- a/docs/cli/analyze.md
+++ b/docs/cli/analyze.md
@@ -12,6 +12,8 @@ archmap analyze [path] [options]
 
 ## Options
 
+### Export
+
 | Option | Default | Description |
 |---|---|---|
 | `--format` | `json` | Output format: `json`, `mermaid`, or `both` |
@@ -19,30 +21,92 @@ archmap analyze [path] [options]
 | `--out-mermaid` | `.codeatlas/graph.mmd` | Mermaid output path |
 | `--out-cytoscape` | `.codeatlas/graph-cytoscape.json` | Cytoscape output path |
 | `--include-cytoscape` | off | Also write Cytoscape JSON |
-| `--top` | `5` | Number of top complexity/risk items printed to terminal |
-| `--fail-on-cycles` | off | Exit code `2` when cycles are found |
-| `--fail-on-layer-violations` | off | Exit code `2` when layer violations are found |
-| `--fail-on-god-modules` | off | Exit code `2` when god modules are found |
-| `--fail-on-dependency-explosions` | off | Exit code `2` when dependency explosions are found |
-| `--fail-on-risks` | off | Exit code `2` when any cycle/risk category is found |
+| `--no-subgraphs` | off | Disable subgraph grouping by layer in Mermaid output |
+| `--sarif` | off | Export a SARIF 2.1.0 report alongside other outputs |
+| `--out-sarif` | auto | Path for the SARIF output file |
+
+### Output control
+
+| Option | Default | Description |
+|---|---|---|
+| `--top N` | `5` | Number of top complexity/risk items printed to terminal |
+| `--summary-format` | `text` | Terminal summary style: `text`, `table`, or `markdown` |
+| `--quiet`, `-q` | off | Suppress banner, insights, and hints — print only violations (useful in CI) |
+| `--include-insights` | on | Print human-oriented architectural insights |
+| `--no-include-insights` | — | Disable insights output |
+| `--include-explanation` | on | Print an automatic project explanation |
+| `--no-include-explanation` | — | Disable explanation output |
+| `--show-unresolved[=N]` | off | Print unresolved import details; `N` controls how many are shown (default 20) |
+
+### Graph filtering
+
+| Option | Default | Description |
+|---|---|---|
+| `--ignore-external` | off | Exclude external package nodes and their edges; focuses graph on internal structure |
+| `--impact PATH` | — | Simulate the architectural impact of changing a specific file |
+
+### Performance
+
+| Option | Default | Description |
+|---|---|---|
+| `--parallel` / `--no-parallel` | on | Enable/disable parallel file parsing |
+| `--no-cache` | off | Skip loading and saving cached analysis results |
+
+### CI quality gates
+
+| Option | Default | Description |
+|---|---|---|
+| `--fail-on-cycles` | off | Exit code `2` when circular dependencies are detected |
+| `--fail-on-layer-violations` | off | Exit code `2` when layer violations are detected |
+| `--fail-on-god-modules` | off | Exit code `2` when god modules are detected |
+| `--fail-on-dependency-explosions` | off | Exit code `2` when dependency explosions are detected |
+| `--fail-on-custom-rules` | off | Exit code `2` when custom architecture rule violations are detected |
+| `--fail-on-risks` | off | Exit code `2` when any cycle or risk category is detected |
+| `--fail-on-budget-violations` | off | Exit code `2` when any file exceeds coupling budgets |
+| `--min-health N` | — | Exit code `2` when architecture health score falls below N (0–100) |
+| `--min-resolution-rate PCT` | — | Exit code `2` when import resolution rate is below PCT percent (0–100) |
+| `--max-outgoing-per-file N` | — | CLI override: max outgoing dependencies per file (overrides `.archmap.toml`) |
+| `--max-incoming-per-file N` | — | CLI override: max incoming dependencies per file (overrides `.archmap.toml`) |
 
 ## Examples
 
 ```bash
-# Analyze current directory, JSON only
+# Analyze current directory
 archmap analyze .
 
 # Analyze specific path, all formats
 archmap analyze ./src --format both
 
-# Include Cytoscape export
-archmap analyze . --format both --include-cytoscape
+# Table-format summary
+archmap analyze . --summary-format table
 
-# Custom output paths
-archmap analyze . --out reports/graph.json --out-mermaid reports/graph.mmd
+# Markdown summary (paste into a PR description)
+archmap analyze . --summary-format markdown
 
-# CI quality gate
-archmap analyze . --fail-on-risks --top 10
+# Show which imports failed to resolve
+archmap analyze . --show-unresolved
+
+# Focus on internal structure only (hide external packages)
+archmap analyze . --ignore-external
+
+# Full CI quality gate
+archmap analyze . \
+  --fail-on-cycles \
+  --fail-on-layer-violations \
+  --fail-on-budget-violations \
+  --max-outgoing-per-file 20 \
+  --min-health 70 \
+  --min-resolution-rate 80 \
+  --quiet
+
+# Coupling budgets from config file (set in .archmap.toml)
+archmap analyze . --fail-on-budget-violations
+
+# SARIF output for GitHub Code Scanning
+archmap analyze . --sarif --out-sarif results/archmap.sarif
+
+# Impact analysis for a specific file
+archmap analyze . --impact src/core/__init__.py
 ```
 
 ## Output
@@ -52,12 +116,31 @@ Prints a summary to stdout:
 ```text
 [ok] 42 files analyzed
 [ok] 130 dependencies detected
-[ok] 3 circular dependencies detected
-Top complexity (imports):
-  - src/main.py: 14 imports (87% score)
+[ok] 0 circular dependencies detected
+[ok] Average instability 38%
+[ok] Import resolution rate 97% (4 unresolved)
+[ok] Architecture health 84/100 (B)
+Top complexity (imports/dependents):
+  - src/main.py: 14 imports, 3 dependents, 17 total, 82% instability (87% score)
 Top risk files:
   - src/core/__init__.py: score 42 (god_module)
 [info] JSON report exported to .codeatlas/graph.json
+```
+
+### Table format (`--summary-format table`)
+
+```text
+──────────────────────────────────────────────────────
+Metric                  Value
+──────────────────────────────────────────────────────
+Files analyzed          42
+Dependencies            130
+Circular dependencies   0
+Average instability     38%
+Import resolution       97% (4 unresolved)
+Architecture health     84/100 (B)
+Detected style          layered (82%)
+──────────────────────────────────────────────────────
 ```
 
 See the [API Reference](../api.md) for the full JSON schema.


### PR DESCRIPTION
## Summary

- **CHANGELOG.md** — preenche a seção `[Unreleased]` com todas as adições e correções do Sprint 1 (post-v0.9.0): per-import unresolved tracking, `--show-unresolved`, coupling budgets, `--ignore-external`, `--summary-format`, fix XSS no badge SVG, fix Config panel UX
- **docs/cli/analyze.md** — tabela de opções reescrita com cobertura completa (~10 flags novas e antigas que não estavam documentadas: `--quiet`, `--no-cache`, `--min-health`, `--min-resolution-rate`, `--summary-format`, `--show-unresolved`, `--ignore-external`, `--fail-on-budget-violations`, `--max-outgoing-per-file`, `--max-incoming-per-file`, `--sarif`, `--no-subgraphs`, `--impact`, `--parallel`, `--include-insights`, `--include-explanation`). Adicionados exemplos de output em formato table/markdown.
- **ROADMAP.md** — adicionada seção `post-v0.9.0 (main — unreleased)` com os itens do Sprint 1; removidos itens já entregues da seção Medium-term (shell completion, Docker, resolution rate, PNG export); consolidada seção Longer-term.

## Checklist

- [x] Ruff clean
- [x] 429 testes passando
- [x] Nenhuma mudança de código — somente documentação


---
_Generated by [Claude Code](https://claude.ai/code/session_0183svB3xX4o72r1QKA2cK4K)_