### PR TITLE
Release v1.0.1 → v1.0.3: security, performance, parser accuracy, tree-sitter overhaul + docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,26 @@ jobs:
         run: python -m archmap.cli.main analyze src/archmap/ --fail-on-cycles --quiet --format json --out .codeatlas/self-check.json
         if: matrix.python-version == '3.13'
 
+  tree-sitter:
+    name: Tests with tree-sitter (AST path)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies (with tree-sitter extra)
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,tree-sitter]"
+
+      - name: Run tests with coverage (tree-sitter active)
+        run: python -m pytest
+
   build-package:
     name: Build Python package (wheel + sdist)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project are documented in this file.
 
+## [1.0.3] - 2026-06-11
+
+Tree-sitter engine overhaul. Tree-sitter becomes a resilient *primary* parser
+with automatic per-file fallback to the regex path. Fully backward-compatible;
+the optional `[tree-sitter]` extra is still optional.
+
+### Added
+- **Per-language grammar availability** — each tree-sitter grammar now loads
+  independently. A single missing or broken grammar (e.g. `tree-sitter-php`) no
+  longer disables tree-sitter for every other language; the affected language
+  simply uses its regex fallback. New `ts_engine.language_available(name)`.
+- **Automatic per-file fallback (`ts_engine.try_extract`)** — the parsers call a
+  single orchestrator that returns the structured tree-sitter result, or `None`
+  to request the regex fallback when tree-sitter cannot be trusted for that file:
+  the grammar is unavailable, parsing/querying raised an exception, or the parse
+  contained syntax errors *and* recovered no imports. Previously a file that made
+  tree-sitter raise was dropped from the graph entirely.
+- **Structured C# extraction** — `using` directives are read from typed AST
+  nodes, so `using Alias = Real.Namespace;` resolves to the real namespace
+  (not the alias), and `global using` / `using static` are handled. This matches
+  the regex fallback's behaviour so both paths agree.
+- **CI now tests both paths** — a dedicated `tree-sitter` job runs the suite with
+  the AST grammars installed, while the existing `quality` job continues to
+  cover the regex fallback. The tree-sitter code path was previously untested in
+  CI.
+
+### Changed
+- Rust regex fallback now strips comments before matching, consistent with the
+  other regex fallbacks introduced in 1.0.2.
+- `ts_engine` extractors were refactored to parse-then-extract from a shared
+  tree, enabling the reliability check without changing their public signatures.
+
 ## [1.0.2] - 2026-06-11
 
 Parser-accuracy release. Every change reduces false positives or raises the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project are documented in this file.
 
+## [1.0.1] - 2026-06-11
+
+Hardening and correctness release. No public API breakage — every change is
+backward-compatible with 1.0.0.
+
+### Security
+- **`serve` binds to `127.0.0.1` by default** (was `0.0.0.0`). Exposing the
+  server on the network now requires an explicit `--host` and prints a warning.
+- **All state-changing / local endpoints gated to loopback** — `/api/project`
+  (switch analyzed directory), `/api/reanalyze`, and `/api/advise` now require a
+  loopback client, matching `/api/open` and `/api/open-file`. Previously a host
+  on the same network could repoint the analyzer at any directory and read its
+  structure via `/api/graph`, or trigger outbound LLM requests (SSRF).
+- **`/api/advise` validates `base_url`** — only well-formed `http`/`https` URLs
+  are forwarded server-side; `file://` and other schemes are rejected.
+
+### Fixed
+- **Whole-graph impact analysis is now O(V+E)** instead of O(V·E). The backward
+  adjacency map is built once and shared across nodes (`impact_analyzer.build_dependents_map`),
+  and the BFS uses a `deque` instead of `list.pop(0)`. Large repositories no
+  longer spend most of the analysis time in impact calculation.
+- **LLM advisor layer-violation rendering** — the prompt read non-existent
+  `fromLayer`/`toLayer` keys and emitted `None -> None`. It now reads the
+  `sourceLayer`/`targetLayer`/`source` fields actually produced by the risk
+  analyzer.
+- **Mermaid label escaping** — labels containing `\n`, `[` `]`, `{` `}`, `<` `>`,
+  `"` or `\` no longer break the generated diagram; labels are quoted and the
+  breaking characters are escaped or substituted.
+
+### Added
+- **tsconfig / jsconfig path-alias resolution** — JS/TS imports that rely on
+  `compilerOptions.baseUrl` and `compilerOptions.paths` (e.g. `@app/*` → `src/*`)
+  now resolve to internal files instead of being reported as external packages,
+  raising `resolutionRate` on real-world TypeScript projects. JSONC comments and
+  trailing commas in the config are tolerated.
+
+### Changed
+- **Coverage gate enforced in CI** — `--cov-fail-under=85` added to the pytest
+  configuration; the suite now fails if coverage regresses below 85%.
+- **Dockerfile pinned to `python:3.13-slim`** (was the unreleased `3.14-slim`).
+
 ## [1.0.0] - 2026-05-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project are documented in this file.
 
+## [1.0.2] - 2026-06-11
+
+Parser-accuracy release. Every change reduces false positives or raises the
+resolution rate of the regex fallbacks (used when the optional `[tree-sitter]`
+extra is not installed). Fully backward-compatible.
+
+### Added
+- **Comment-aware regex fallbacks** — a shared, string-aware `strip_comments`
+  pass removes `//`, `/* */` (and `#` for PHP) comments before import matching,
+  so import-like text inside comments no longer produces phantom dependencies.
+  Applied to JavaScript/TypeScript, Java, C#, PHP and C/C++. String literals
+  (e.g. `require("x")`, `#include "x"`) are preserved, and line structure is
+  kept intact for `re.MULTILINE` matching.
+- **Go `replace` directives** — local replacements in `go.mod`
+  (`replace x => ./local`) now resolve imports to the replaced directory instead
+  of reporting them as external packages.
+- **PHP composer PSR-4 autoload** — `use` statements resolve through the
+  `autoload`/`autoload-dev` `psr-4` map in `composer.json` (longest prefix wins),
+  replacing the previous fragile suffix-matching heuristic for configured roots.
+- **C# alias and `global using`** — `using Alias = Real.Namespace;` now extracts
+  the right-hand namespace (previously captured the alias name), and
+  `global using` directives are recognized.
+- **Java inner-class resolution** — `import com.example.Outer.Inner;` resolves to
+  `com/example/Outer.java` when no `Inner` compilation unit exists.
+- **C/C++ include-dir resolution** — a header included as `"foo/bar.h"` resolves
+  to a unique `include/foo/bar.h` or `src/foo/bar.h` via path-suffix matching,
+  covering the common `-I` include-directory layout.
+
+### Changed
+- C# `using static System.Math;` now parses to the `System.Math` namespace
+  (the `static` directive keyword is no longer kept in the parsed value).
+
 ## [1.0.1] - 2026-06-11
 
 Hardening and correctness release. No public API breakage — every change is

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.13-slim
 
 LABEL org.opencontainers.image.title="ArchMAP" \
       org.opencontainers.image.description="Static architecture analysis and visualization for software projects." \

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <img src="https://img.shields.io/badge/license-MIT-green" alt="License: MIT"/>
   </a>
   <a href="./CHANGELOG.md">
-    <img src="https://img.shields.io/badge/version-1.0.1-brightgreen" alt="Version"/>
+    <img src="https://img.shields.io/badge/version-1.0.2-brightgreen" alt="Version"/>
   </a>
   <a href="https://pypi.org/project/KG-ARCHMAP/">
     <img src="https://img.shields.io/badge/PyPI-KG--ARCHMAP-orange?logo=pypi&logoColor=white" alt="PyPI"/>
@@ -34,7 +34,7 @@ ArchMAP scans source code, builds dependency graphs, detects cycles, reports arc
 
 | | |
 |---|---|
-| Release | `v1.0.1` |
+| Release | `v1.0.2` |
 | Runtime | Python `>=3.11` |
 | UI | built-in static UI + Node dev server |
 | Distribution | PyPI (`KG-ARCHMAP`) + Windows `.exe` |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <img src="https://img.shields.io/badge/license-MIT-green" alt="License: MIT"/>
   </a>
   <a href="./CHANGELOG.md">
-    <img src="https://img.shields.io/badge/version-1.0.2-brightgreen" alt="Version"/>
+    <img src="https://img.shields.io/badge/version-1.0.3-brightgreen" alt="Version"/>
   </a>
   <a href="https://pypi.org/project/KG-ARCHMAP/">
     <img src="https://img.shields.io/badge/PyPI-KG--ARCHMAP-orange?logo=pypi&logoColor=white" alt="PyPI"/>
@@ -34,7 +34,7 @@ ArchMAP scans source code, builds dependency graphs, detects cycles, reports arc
 
 | | |
 |---|---|
-| Release | `v1.0.2` |
+| Release | `v1.0.3` |
 | Runtime | Python `>=3.11` |
 | UI | built-in static UI + Node dev server |
 | Distribution | PyPI (`KG-ARCHMAP`) + Windows `.exe` |
@@ -183,7 +183,7 @@ Install the `[tree-sitter]` extra for AST-based parsing across all 9 languages (
 pip install "KG-ARCHMAP[tree-sitter]"
 ```
 
-When installed, all language parsers upgrade automatically. The regex fallback is preserved — no behaviour change without the extra.
+When installed, all language parsers upgrade automatically. Tree-sitter is used as a resilient *primary* parser: each grammar loads independently, and if it cannot parse a given file (or parses it unreliably), that single file transparently falls back to the regex path instead of being dropped. The regex fallback is fully preserved — no behaviour change without the extra.
 
 ## VS Code Extension
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <img src="https://img.shields.io/badge/license-MIT-green" alt="License: MIT"/>
   </a>
   <a href="./CHANGELOG.md">
-    <img src="https://img.shields.io/badge/version-1.0.0-brightgreen" alt="Version"/>
+    <img src="https://img.shields.io/badge/version-1.0.1-brightgreen" alt="Version"/>
   </a>
   <a href="https://pypi.org/project/KG-ARCHMAP/">
     <img src="https://img.shields.io/badge/PyPI-KG--ARCHMAP-orange?logo=pypi&logoColor=white" alt="PyPI"/>
@@ -34,7 +34,7 @@ ArchMAP scans source code, builds dependency graphs, detects cycles, reports arc
 
 | | |
 |---|---|
-| Release | `v1.0.0` |
+| Release | `v1.0.1` |
 | Runtime | Python `>=3.11` |
 | UI | built-in static UI + Node dev server |
 | Distribution | PyPI (`KG-ARCHMAP`) + Windows `.exe` |
@@ -108,8 +108,18 @@ archmap analyze . --show-unresolved=20
 ### Serve
 
 ```bash
+# Binds to 127.0.0.1 by default (loopback only).
+archmap serve <path> --port 3000
+
+# Expose on the network explicitly (prints a security warning).
 archmap serve <path> --host 0.0.0.0 --port 3000
 ```
+
+> **Security note:** endpoints that read local files, switch the analyzed
+> project, or call an LLM (`/api/open`, `/api/open-file`, `/api/project`,
+> `/api/reanalyze`, `/api/advise`) are restricted to loopback requests
+> regardless of `--host`. Only the read-only graph/health endpoints are
+> reachable from other hosts when you bind to `0.0.0.0`.
 
 ### Diff
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,10 @@
 
 ## Released
 
+### v1.0.2 (2026-06-11)
+- **Parser accuracy** — comment-aware regex fallbacks (no more phantom imports from comments) across JS/TS, Java, C#, PHP, C/C++.
+- **Config-aware resolution** — Go `replace` directives, PHP composer PSR-4 autoload, Java inner classes, C# aliases + `global using`, C/C++ include-dir suffix matching.
+
 ### v1.0.1 (2026-06-11)
 - **Security hardening** — `serve` binds to loopback by default; state-changing and local endpoints (`/api/project`, `/api/reanalyze`, `/api/advise`) gated to loopback; `/api/advise` validates `base_url` scheme.
 - **Impact analysis O(V·E) → O(V+E)** — shared backward-adjacency map + `deque` BFS.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,13 @@
 
 ## Released
 
+### v1.0.1 (2026-06-11)
+- **Security hardening** — `serve` binds to loopback by default; state-changing and local endpoints (`/api/project`, `/api/reanalyze`, `/api/advise`) gated to loopback; `/api/advise` validates `base_url` scheme.
+- **Impact analysis O(V·E) → O(V+E)** — shared backward-adjacency map + `deque` BFS.
+- **Bug fixes** — LLM advisor layer-violation field names; Mermaid label escaping.
+- **tsconfig/jsconfig `paths` + `baseUrl` resolution** for JS/TS imports (improves resolution rate).
+- **CI coverage gate** (`--cov-fail-under=85`); Dockerfile pinned to `python:3.13-slim`.
+
 ### v1.0.0 (2026-05-25)
 - **`archmap temporal`** — temporal coupling analysis via `git log`. Detects files that change together, ranked by co-change frequency and coupling strength. `--min-commits`, `--top`, `--json` flags. Zero new deps.
 - **Web UI SVG export** — "SVG" button in canvas toolbar. Scalable vector download via `cy.svg({ full: true })`. Zero new deps.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,11 @@
 
 ## Released
 
+### v1.0.3 (2026-06-11)
+- **Tree-sitter as resilient primary parser** — per-language grammar availability + automatic per-file fallback to regex (`try_extract`) when a parse fails or is unreliable (no more dropped files).
+- **Structured C# extraction** (aliases, `global using`, `static`) via typed AST nodes.
+- **CI tests both the AST and regex paths** (dedicated `tree-sitter` job).
+
 ### v1.0.2 (2026-06-11)
 - **Parser accuracy** — comment-aware regex fallbacks (no more phantom imports from comments) across JS/TS, Java, C#, PHP, C/C++.
 - **Config-aware resolution** — Go `replace` directives, PHP composer PSR-4 autoload, Java inner classes, C# aliases + `global using`, C/C++ include-dir suffix matching.

--- a/docs/api.md
+++ b/docs/api.md
@@ -241,11 +241,21 @@ Full node and edge objects for the Web UI and Cytoscape integration.
 
 ---
 
-## Web UI live endpoint
+## Web UI live endpoints
 
-When `archmap serve` is running, the same report is available at:
+When `archmap serve` is running, the report and related endpoints are available:
 
 ```
-GET http://localhost:3000/api/graph   → application/json (full report)
-GET http://localhost:3000/api/health  → {"status":"ok"}
+GET  http://localhost:3000/api/graph   → application/json (full report)
+GET  http://localhost:3000/api/health  → {"status":"ok"}
+GET  http://localhost:3000/api/badge   → image/svg+xml (health badge)
+GET  http://localhost:3000/api/project → {"path": "..."}
 ```
+
+State-changing and local endpoints (`POST /api/reanalyze`, `POST /api/project`,
+`POST /api/advise`, `POST /api/open`, `POST /api/open-file`) are **restricted to
+loopback clients** (`127.0.0.1` / `::1`) and return `403` otherwise, even when the
+server is bound to `0.0.0.0`. `/api/advise` additionally validates that `base_url`
+is a well-formed `http`/`https` URL before forwarding the request server-side.
+
+See [`serve`](cli/serve.md#security) for the full endpoint table and the security model.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,16 +40,51 @@ Discovers all source files under `project_path` and calls the language-specific 
 
 | Sub-parser | Language | Strategy |
 |---|---|---|
-| `python_parser.py` | Python | AST walk — captures `import X`, `from X import Y` |
-| `js_parser.py` | JavaScript | Regex — `import`, `require`, `export ... from`, dynamic `import()` |
-| `ts_parser.py` | TypeScript | Same as JS |
-| `rust_parser.py` | Rust | Regex — `use`, `mod`, `extern crate` |
+| `python_parser.py` | Python | `ast` walk — `import X`, `from X import Y` (regex on `SyntaxError`) |
+| `js_parser.py` | JavaScript | tree-sitter / regex — `import`, `require`, `export … from`, dynamic `import()` |
+| `ts_parser.py` | TypeScript | tree-sitter / regex — JS rules + triple-slash references |
+| `rust_parser.py` | Rust | tree-sitter / regex — `use`, `mod`, `extern crate` |
+| `go_parser.py` | Go | tree-sitter / regex — single + block imports |
+| `php_parser.py` | PHP | tree-sitter / regex — `use`, `require`, `include` |
+| `java_parser.py` | Java | tree-sitter / regex — `import`, `import static`, wildcards |
+| `csharp_parser.py` | C# | tree-sitter / regex — `using`, `global using`, aliases |
+| `cpp_parser.py` | C / C++ | tree-sitter / regex — `#include <…>` vs `#include "…"` |
 
-Dependency resolution (`_resolve_python_dependency`, `_resolve_js_ts_dependency`, etc.) maps each import string to:
+### Tree-sitter as a resilient primary parser
+
+Except for Python (which uses the standard-library `ast`), every parser routes
+through `ts_engine.try_extract(language, source)`:
+
+1. **Tree-sitter first.** When the optional `[tree-sitter]` extra is installed, a
+   real AST is used. Grammars load **independently** — a single missing or broken
+   grammar does not disable the others (`ts_engine.language_available(name)`).
+2. **Automatic per-file fallback.** `try_extract` returns `None` — asking the
+   parser to use its comment-aware regex fallback — whenever tree-sitter cannot be
+   trusted for that file: the grammar is unavailable, parsing/querying raised, or
+   the parse contained syntax errors *and* recovered no imports. A problematic file
+   is never silently dropped from the graph.
+3. **Regex fallback.** Without the extra, every parser uses a string-aware regex
+   pass that strips comments before matching, so import-like text in comments does
+   not create phantom dependencies.
+
+### Dependency resolution
+
+Resolution (`_resolve_python_dependency`, `_resolve_js_ts_dependency`, etc.) maps each import to:
+
 - An **internal file ID** (`type: "file"`) when the path exists in the project
 - An **external package** (`type: "package"`, id prefixed with `pkg:`) otherwise
 
-For Python absolute `from pkg import name` imports, each imported name is checked as a potential submodule (`pkg/name.py`, `pkg/name/__init__.py`) before falling back to the package root.
+Resolution is configuration-aware where the ecosystem provides it:
+
+| Language | Configuration honored |
+|---|---|
+| Python | absolute `from pkg import name` checked as submodule (`pkg/name.py`, `pkg/name/__init__.py`) before the package root |
+| JS / TS | `tsconfig.json` / `jsconfig.json` `baseUrl` + `paths` aliases (e.g. `@app/*` → `src/*`) |
+| Go | `go.mod` module path and local `replace` directives |
+| PHP | `composer.json` PSR-4 autoload map (longest prefix wins) |
+| Java | package → directory, wildcard packages, and inner classes (`Outer.Inner` → `Outer.java`) |
+| C# | namespace → directory; alias `using X = …` resolves the right-hand namespace |
+| C / C++ | local includes relative to the file, then `include/`-style suffix matching |
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,297 @@
 # Changelog
 
-All notable user-facing changes are tracked in the repository changelog:
+All notable changes to this project are documented in this file.
 
-- https://github.com/Kaua-KGzin/ArchMAP/blob/main/CHANGELOG.md
+## [1.0.3] - 2026-06-11
+
+Tree-sitter engine overhaul. Tree-sitter becomes a resilient *primary* parser
+with automatic per-file fallback to the regex path. Fully backward-compatible;
+the optional `[tree-sitter]` extra is still optional.
+
+### Added
+- **Per-language grammar availability** — each tree-sitter grammar now loads
+  independently. A single missing or broken grammar (e.g. `tree-sitter-php`) no
+  longer disables tree-sitter for every other language; the affected language
+  simply uses its regex fallback. New `ts_engine.language_available(name)`.
+- **Automatic per-file fallback (`ts_engine.try_extract`)** — the parsers call a
+  single orchestrator that returns the structured tree-sitter result, or `None`
+  to request the regex fallback when tree-sitter cannot be trusted for that file:
+  the grammar is unavailable, parsing/querying raised an exception, or the parse
+  contained syntax errors *and* recovered no imports. Previously a file that made
+  tree-sitter raise was dropped from the graph entirely.
+- **Structured C# extraction** — `using` directives are read from typed AST
+  nodes, so `using Alias = Real.Namespace;` resolves to the real namespace
+  (not the alias), and `global using` / `using static` are handled. This matches
+  the regex fallback's behaviour so both paths agree.
+- **CI now tests both paths** — a dedicated `tree-sitter` job runs the suite with
+  the AST grammars installed, while the existing `quality` job continues to
+  cover the regex fallback. The tree-sitter code path was previously untested in
+  CI.
+
+### Changed
+- Rust regex fallback now strips comments before matching, consistent with the
+  other regex fallbacks introduced in 1.0.2.
+- `ts_engine` extractors were refactored to parse-then-extract from a shared
+  tree, enabling the reliability check without changing their public signatures.
+
+## [1.0.2] - 2026-06-11
+
+Parser-accuracy release. Every change reduces false positives or raises the
+resolution rate of the regex fallbacks (used when the optional `[tree-sitter]`
+extra is not installed). Fully backward-compatible.
+
+### Added
+- **Comment-aware regex fallbacks** — a shared, string-aware `strip_comments`
+  pass removes `//`, `/* */` (and `#` for PHP) comments before import matching,
+  so import-like text inside comments no longer produces phantom dependencies.
+  Applied to JavaScript/TypeScript, Java, C#, PHP and C/C++. String literals
+  (e.g. `require("x")`, `#include "x"`) are preserved, and line structure is
+  kept intact for `re.MULTILINE` matching.
+- **Go `replace` directives** — local replacements in `go.mod`
+  (`replace x => ./local`) now resolve imports to the replaced directory instead
+  of reporting them as external packages.
+- **PHP composer PSR-4 autoload** — `use` statements resolve through the
+  `autoload`/`autoload-dev` `psr-4` map in `composer.json` (longest prefix wins),
+  replacing the previous fragile suffix-matching heuristic for configured roots.
+- **C# alias and `global using`** — `using Alias = Real.Namespace;` now extracts
+  the right-hand namespace (previously captured the alias name), and
+  `global using` directives are recognized.
+- **Java inner-class resolution** — `import com.example.Outer.Inner;` resolves to
+  `com/example/Outer.java` when no `Inner` compilation unit exists.
+- **C/C++ include-dir resolution** — a header included as `"foo/bar.h"` resolves
+  to a unique `include/foo/bar.h` or `src/foo/bar.h` via path-suffix matching,
+  covering the common `-I` include-directory layout.
+
+### Changed
+- C# `using static System.Math;` now parses to the `System.Math` namespace
+  (the `static` directive keyword is no longer kept in the parsed value).
+
+## [1.0.1] - 2026-06-11
+
+Hardening and correctness release. No public API breakage — every change is
+backward-compatible with 1.0.0.
+
+### Security
+- **`serve` binds to `127.0.0.1` by default** (was `0.0.0.0`). Exposing the
+  server on the network now requires an explicit `--host` and prints a warning.
+- **All state-changing / local endpoints gated to loopback** — `/api/project`
+  (switch analyzed directory), `/api/reanalyze`, and `/api/advise` now require a
+  loopback client, matching `/api/open` and `/api/open-file`. Previously a host
+  on the same network could repoint the analyzer at any directory and read its
+  structure via `/api/graph`, or trigger outbound LLM requests (SSRF).
+- **`/api/advise` validates `base_url`** — only well-formed `http`/`https` URLs
+  are forwarded server-side; `file://` and other schemes are rejected.
+
+### Fixed
+- **Whole-graph impact analysis is now O(V+E)** instead of O(V·E). The backward
+  adjacency map is built once and shared across nodes (`impact_analyzer.build_dependents_map`),
+  and the BFS uses a `deque` instead of `list.pop(0)`. Large repositories no
+  longer spend most of the analysis time in impact calculation.
+- **LLM advisor layer-violation rendering** — the prompt read non-existent
+  `fromLayer`/`toLayer` keys and emitted `None -> None`. It now reads the
+  `sourceLayer`/`targetLayer`/`source` fields actually produced by the risk
+  analyzer.
+- **Mermaid label escaping** — labels containing `\n`, `[` `]`, `{` `}`, `<` `>`,
+  `"` or `\` no longer break the generated diagram; labels are quoted and the
+  breaking characters are escaped or substituted.
+
+### Added
+- **tsconfig / jsconfig path-alias resolution** — JS/TS imports that rely on
+  `compilerOptions.baseUrl` and `compilerOptions.paths` (e.g. `@app/*` → `src/*`)
+  now resolve to internal files instead of being reported as external packages,
+  raising `resolutionRate` on real-world TypeScript projects. JSONC comments and
+  trailing commas in the config are tolerated.
+
+### Changed
+- **Coverage gate enforced in CI** — `--cov-fail-under=85` added to the pytest
+  configuration; the suite now fails if coverage regresses below 85%.
+- **Dockerfile pinned to `python:3.13-slim`** (was the unreleased `3.14-slim`).
+
+## [1.0.0] - 2026-05-25
+
+### Added
+- **`archmap temporal`** — temporal coupling analysis via `git log`. Detects files that frequently change together in commits — hidden coupling not visible in static imports. Outputs ranked pairs with co-change count and coupling strength (0–1). Flags: `--min-commits N`, `--top N`, `--json`. Zero new dependencies (stdlib `subprocess` only).
+- **Web UI — SVG export** — "SVG" button in the canvas toolbar next to PNG. Uses Cytoscape.js native `cy.svg({ full: true })` API and downloads as `archmap-graph.svg`. Scalable vector output, zero new dependencies.
+- **MCP server** (`archmap mcp`) — exposes the ArchMAP analysis engine as a JSON-RPC 2.0 server over stdio. Four tools: `get_architecture_summary`, `get_file_context`, `impact_analysis`, `run_checks`. Compatible with Claude Code, Cursor, Windsurf, and any MCP-capable AI assistant.
+
+### Changed
+- **Stable public Python API** — `from archmap import analyze_project, AnalysisResult` is now fully typed and considered stable. All types exported from `archmap.types`. Zero-breaking-change commitment for all 1.x releases.
+- **mypy strict enforcement** — 0 type errors enforced as a blocking CI gate. All new code must pass mypy at the same strictness level.
+- **Test coverage** — raised to 88% (from 85% in v0.9.0). New test files: `test_reachability_analyzer`, `test_generic_parser`, `test_rust_go_parsers`, `test_temporal_analyzer`.
+
+### Migration from 0.x
+
+No breaking changes. The `analyze_project()` function and all return types are backward-compatible with 0.9.0. The only additions are:
+- New `archmap temporal` subcommand.
+- New SVG export button in the Web UI.
+- New `archmap mcp` subcommand (available since 0.9.x, now stable).
+- `from archmap import AnalysisResult` and all sibling types are now part of the public API contract.
+
+## [Unreleased]
+
+### Added
+- **Tree-sitter multi-language parser** — optional `[tree-sitter]` extra (`pip install archmap[tree-sitter]`) replaces every regex-based parser with a proper AST engine. When the extra is installed, all nine language parsers use tree-sitter grammars:
+  - **JavaScript / TypeScript** — `tree-sitter-javascript` / `tree-sitter-typescript` (+ TSX variant). Multiline imports, `import type`, `export type` all handled correctly. Import-like text in string literals and comments no longer produces false positives.
+  - **Java** — `tree-sitter-java`. Static imports, wildcard imports (`com.example.*`), and standard imports all resolved correctly.
+  - **Go** — `tree-sitter-go`. Both single-import and block-import forms captured without regex edge cases.
+  - **Rust** — `tree-sitter-rust`. `use`, `mod`, and `extern crate` declarations extracted and normalised using the existing `_normalize_rust_use` logic.
+  - **PHP** — `tree-sitter-php`. Handles both single-quoted and double-quoted strings, and the parenthesized call form (`require('x')`).
+  - **C#** — `tree-sitter-c-sharp`. `using`, `using static`, and alias directives.
+  - **C / C++** — `tree-sitter-c` / `tree-sitter-cpp`. `#include <system>` and `#include "local"` correctly distinguished by node type.
+  - The regex fallback is preserved in all parsers; no behaviour change when the extra is not installed.
+- **Per-import unresolved tracking** — parser now resolves each import statement individually. `importsTotal`, `importsResolved`, and `unresolvedImports` fields on every `ParsedFile`. `metrics.unresolvedImports` and `metrics.unresolvedImportsTotal` in the graph report.
+- **`--show-unresolved[=N]`** — prints a detailed list of import statements that could not be resolved (file + specifier). `N` controls how many are shown (default 20 when flag is present).
+- **`--fail-on-budget-violations`** — CI gate that exits with code 2 when any file exceeds coupling budgets. Works with CLI overrides or `.archmap.toml`.
+- **`--max-outgoing-per-file N`** — CLI override for maximum allowed outgoing dependencies per file.
+- **`--max-incoming-per-file N`** — CLI override for maximum allowed incoming dependencies per file.
+- **`[analysis.budgets]` in `.archmap.toml`** — `max_outgoing_per_file` and `max_incoming_per_file` config keys for project-wide coupling limits.
+- **`--ignore-external`** — strips external package nodes (e.g. `pkg:requests`) and their edges from the output graph. Metrics are recomputed after filtering. Useful for focusing on internal structure only.
+- **`--summary-format {text,table,markdown}`** — controls the terminal summary output style. `text` (default) is the existing `[ok]/[warn]` format; `table` renders an aligned ASCII table with separator lines; `markdown` renders a pipe-delimited markdown table for pasting into docs or PRs.
+
+### Fixed
+- **SVG injection in `/api/badge`** — health grade string is now XML-escaped via `xml.sax.saxutils.escape` before being embedded in the SVG response. Prevents XSS if a grade value ever contained `<`, `>`, or `&`.
+- **Web UI Config navigation** — Config panel is now accessible via a dedicated gear-icon button in the nav rail (`navBtnConfig`). The ArchMAP logo click is restored to its original behavior: navigating to the Graph view. Previously the logo opened Config, leaving no dedicated button and no way to return to the graph.
+- **`_VALID_LLM_PROVIDERS` scoping in `server.py`** — moved to module-level `frozenset` constant; previously re-declared as a local variable inside `_handle_advise` on every request.
+
+## [0.9.0] - 2026-05-08
+
+### Added
+- **Parser resolution rate** — `resolutionRate` metric (0.0–1.0) now included in every analysis report. Tracks what fraction of import statements were successfully resolved to a file or package. Visible in the CLI summary (warns when below 70%), in the Web UI Insights panel, and in JSON output (`metrics.resolutionRate`). New `--min-resolution-rate PCT` flag gates CI on this metric (e.g. `--min-resolution-rate 70`).
+- **Shell completion** — `archmap --print-completion bash|zsh|fish` prints the shell-specific setup command. Install the `argcomplete` optional dep (`pip install archmap[completion]`) and add the printed line to your shell profile for full tab-completion of all subcommands and flags.
+- **Web UI — PNG export** — "PNG" download button in the canvas toolbar. Exports the current dependency graph as a 2× scale PNG using Cytoscape.js's native `cy.png()` API. Zero new dependencies.
+- **Docker image** — `ghcr.io/kaua-kgzin/archmap:latest` published automatically on each GitHub release. Includes `:X.Y.Z` and `:X.Y` version tags. Use `docker run -p 3000:3000 -v $(pwd):/project ghcr.io/kaua-kgzin/archmap` to start the Web UI.
+- **Web UI — i18n** — Full interface internationalization: English, Português (Brasil), Español, Français, Deutsch, 中文 (简体). Language selector in the Config panel; setting persists across sessions and applies instantly without reload.
+- **Web UI — Config panel** — Clicking the ArchMAP logo opens a persistent settings panel: Interface (language), General (auto-save config, animations toggle), Graph (default layout: cose/breadthfirst/concentric/circle/grid), LLM Advisor, Scan Languages. All settings saved to localStorage.
+- **Web UI — Advisor persistence** — LLM provider, model, base URL, and API key are saved to localStorage and restored on every session. Auto-save mode writes on every keystroke.
+
+### Changed
+- `metrics.resolutionRate` field added to the JSON report schema (always present, defaults to `1.0` when no imports are found).
+
+## [0.8.0] - 2026-05-07
+
+### Added
+- **`archmap trace <entrypoint>`** — BFS reachability analysis from any source file: shows the full dependency tree by depth level, coverage percentage, and optionally lists unreachable files (`--unreachable`). Supports `--max-depth`, `--json`, and `--out`.
+- **`archmap advise`** — LLM-powered architectural advisor. Sends a compact report summary to an LLM and returns concrete refactoring advice. Supports multiple providers with zero new runtime dependencies (pure `urllib`):
+  - `--provider claude` — Anthropic API (reads `ANTHROPIC_API_KEY`)
+  - `--provider openai` — OpenAI API (reads `OPENAI_API_KEY`)
+  - `--provider ollama` — local Ollama instance (default `http://localhost:11434`)
+  - `--provider custom --base-url <url>` — any OpenAI-compatible endpoint (LM Studio, etc.)
+  - `--model`, `--api-key`, `--timeout` flags for full control.
+- **`archmap init --from-analysis`** — analyzes the project first and derives `.archmap.toml` layer rules from actual dependency direction (files with higher fan-in rank as more foundational), including detected `forbid` rules from live violations.
+- **`archmap diff --snapshot-a <file> --snapshot-b <file>`** — compare two exported JSON snapshots directly, without requiring git refs. Useful for cross-machine or cross-deploy comparisons.
+- **VS Code extension** (`vscode-extension/`) — zero-config IDE integration:
+  - Inline diagnostics in the Problems panel for cycles, layer violations, god modules, and custom rule violations.
+  - Status bar item with live health score and grade.
+  - `ArchMAP: Analyze Project` command.
+  - `ArchMAP: Open Web UI` command (launches `archmap serve` and opens browser).
+  - `ArchMAP: Trace File Reachability` command — opens a webview with the BFS depth tree.
+  - `archmap.analyzeOnSave` setting for CI-style continuous feedback.
+
+## [0.7.2] - 2026-04-27
+
+### Added
+- **Web UI — multi-view navigation**: nav rail now switches between three independent left-panel views (Graph, Insights, Rules & Layers).
+- **Web UI — Layer Diagram tab**: new canvas tab renders the dependency graph with a hierarchical breadth-first layout and a floating legend.
+- **Web UI — Dependency Matrix tab**: new canvas tab renders the top-25 most-connected files as a colour-coded dependency matrix (dependency, circular, self-reference).
+- **Web UI — Insights panel**: architecture metrics summary cards populated live from report data (health score, files, cycles, complexity, etc.).
+- **Web UI — Rules & Layers panel**: displays layer rule cards from `.archmap.toml`; shows a "no rules configured" placeholder when absent.
+- Breadcrumb and canvas title update dynamically when switching canvas tabs.
+
+## [0.7.1] - 2026-04-27
+
+### Fixed
+- **Web UI**: bundle Cytoscape 3.30.2 locally — eliminates CDN dependency and fixes broken graph (CSP was blocking `unpkg.com`).
+- **Web UI**: correct Content-Security-Policy to allow Google Fonts while keeping scripts same-origin.
+- **CI (windows-exe)**: add `pillow` to PyInstaller deps so `icon.png` → `.ico` conversion works on the runner.
+- **PyPI publish**: align package name with PyPI project (`KG-ARCHMAP`) so OIDC trusted publisher accepts uploads.
+- **PyPI publish**: add `skip-existing: true` to avoid 400 errors on re-runs of the same tag.
+
+### Changed
+- **Web UI**: complete visual refresh — Inter + JetBrains Mono fonts, indigo design system, architecture health gauge, KPI tiles, ranked critical files list, selection grid, status bar, mini-map overlay.
+
+## [0.7.0] - 2026-04-24
+
+### Added
+- **TypeScript parser** with triple-slash reference support (`/// <reference path="..." />`).
+- **Reusable GitHub Action** (`action.yml`) — run ArchMAP analysis directly in any workflow with SARIF upload to GitHub Code Scanning.
+- **Pre-commit hook** via the `archmap-check` entrypoint — integrates with `.pre-commit-hooks.yaml` for zero-config quality gates.
+- **Incremental parse cache** — unchanged files are skipped on re-analysis, reducing runtime on large repos.
+- **`--sarif` flag** on `archmap analyze` — exports findings as SARIF 2.1.0 for upload to Code Scanning or SAST tools.
+
+### Changed
+- Parser registry now self-registers at import time; `bootstrap.py` is a no-op retained for backwards compatibility.
+- Web UI simplified: removed i18n layer, reduced bundle size.
+- `archmap-check` pre-commit entrypoint defaults: `--quiet --fail-on-cycles --fail-on-custom-rules`.
+
+### Removed
+- `architecture_analyzer`, `architecture_suggester`, `history_analyzer`, `human_analyzer`, `impact_analyzer` — these experimental analyzers were removed to reduce scope and maintenance burden.
+- `explain`, `risk`, `improve`, `history` CLI commands — backends removed; commands raise `NotImplementedError` and will be fully cleaned from the CLI in v0.8.0.
+- i18n layer from the web UI (`i18n.js`).
+
+## [0.4.0-beta.0] - 2026-03-09
+
+### Added
+- **Multi-Language Registry:** Overhauled the parser architecture to support plugin-based language detection. Added support for **Go, PHP, Java, C#, C, and C++**.
+- **"UI of Respect" (Web UI v2):**
+  - **Dark Mode Support:** Full dark theme with session persistence.
+  - **Architectural Risks Panel:** Live detection of circular dependencies and "Hub modules".
+  - **Dynamic Project Import:** New folder icon in the UI allows switching the analysis target on the fly via a native directory picker (no restart required).
+  - **Real-time Refresh:** Manual data re-polling for instant graph updates.
+- **Respectful Executable (EXE):**
+  - **Standalone Launcher:** Double-clicking the EXE now automatically launches the interactive Service Map.
+  - **Persistent Error Log:** Added a "Press Enter to exit" pause on errors in the frozen executable for easier troubleshooting.
+  - **Premium Branding:** Embedded high-resolution project icon and professional CLI banner.
+
+### Fixed
+- **CI Stabilization:** Resolved 22 linting regressions and updated the test suite to ensure 100% compatibility with the new parser architecture.
+- **Repository Cleanup:** Removed redundant legacy JavaScript files from the root to ensure a clean Python-centric distribution.
+
+## [0.2.1] - 2026-03-07
+
+### Added
+- **OSS Professionalization:** Added Issue Templates (Bug/Feature), Code of Conduct, and detailed architecture & API documentation.
+- **Documentation Site:** Implemented MkDocs Material site with automated GitHub Pages deployment.
+- **Professional CI:** Expanded CI to test against Python 3.11, 3.12, and 3.13.
+- **Automated Releases:** Added GitHub Actions workflow to automate package building and releases on version tags.
+- **Rich Examples:** Enriched `examples/sample-project` with intentional cycles and layer violations for demonstration.
+- **Benchmark Tool:** Added `scripts/benchmark.py` for performance testing.
+
+### Fixed
+- **Static Assets:** Fixed "Web UI static directory not found" error in packaged (wheel) installations by using `importlib.resources`.
+- **Parser Precision:** Fixed dependency resolution for absolute `from ... import ...` submodules that were previously misidentified as package-level dependencies.
+
+## [0.1.3] - 2026-03-05
+
+### Added
+- **Single File Analysis:** Added support to natively read and resolve dependencies starting from a single file instead of a full directory scan, reducing overhead and providing concise maps for entry files.
+- **Standalone Windows Executable (`.exe`):** Bundled the CLI and the Web UI into a completely portable, zero-dependency Windows executable via PyInstaller. The interactive graph server (`archmap.exe serve .`) operates directly without a Python runtime requirement.
+
+### Changed
+- Rebuilt architecture file crawler (`file_utils.discover_source_files`) to intercept root files before deep recursive searches.
+
+## [0.2.0-beta.0] - 2026-03-04
+
+### Added
+- Full Python implementation under `src/archmap`.
+- New Python CLI with commands:
+  - `analyze`
+  - `serve`
+  - `diff`
+- Architecture risk engine with:
+  - god module detection
+  - layer violation detection
+  - dependency explosion detection
+- Cytoscape exporter (`cytoscape_exporter.py`).
+- `pyproject.toml` with package metadata and scripts.
+- Pytest suite for parser, analyzer, exporters, CLI, and diff.
+- CI pipeline with Ruff lint + pytest coverage + smoke analysis.
+
+### Changed
+- Canonical runtime migrated from Node.js to Python.
+- Repository structure aligned to `src/archmap` layout.
+- Branch strategy documented as:
+  - `feature/* -> dev -> release/* -> main`
+
+### Notes
+- JavaScript implementation is no longer the primary runtime.
+- Next target: `v0.3.0` architecture policy and trend analysis.

--- a/docs/cli/serve.md
+++ b/docs/cli/serve.md
@@ -14,7 +14,7 @@ archmap serve [path] [options]
 
 | Option | Default | Description |
 |---|---|---|
-| `--host` | `0.0.0.0` | Host/interface to bind the server |
+| `--host` | `127.0.0.1` | Host/interface to bind the server. Use `0.0.0.0` to expose on the network (prints a security warning) |
 | `--port` | `3000` | Port to listen on |
 | `--no-open` | off | Skip opening the browser automatically |
 | `--format` | `both` | Output format for exports: `json`, `mermaid`, or `both` |
@@ -37,24 +37,47 @@ archmap serve . --no-open
 # Serve a specific project
 archmap serve /path/to/project --port 4000
 
-# Bind to localhost only
-archmap serve . --host 127.0.0.1 --port 4000
+# Expose on the network (explicit opt-in; prints a security warning)
+archmap serve . --host 0.0.0.0 --port 4000
 ```
 
 ## Live API endpoints
 
 While running, the server exposes:
 
-| Endpoint | Description |
-|---|---|
-| `GET /` | Interactive graph UI |
-| `GET /api/graph` | Full JSON report (same as `archmap analyze` output) |
-| `GET /api/project` | Current analyzed project path |
-| `GET /api/health` | `{"status":"ok"}` |
-| `POST /api/reanalyze` | Recompute report for current project path |
-| `POST /api/open` | Open folder picker and switch project |
+| Endpoint | Method | Scope | Description |
+|---|---|---|---|
+| `/` | GET | any | Interactive graph UI |
+| `/api/graph` | GET | any | Full JSON report (same as `archmap analyze` output) |
+| `/api/project` | GET | any | Current analyzed project path |
+| `/api/health` | GET | any | `{"status":"ok"}` |
+| `/api/badge` | GET | any | Architecture health badge (SVG, for README embedding) |
+| `/api/history` | GET | any | Temporal coupling history snapshots |
+| `/api/events` | GET | any | Server-sent events stream for live UI refresh |
+| `/api/reanalyze` | POST | loopback | Recompute the report for the current project |
+| `/api/project` | POST | loopback | Switch the analyzed directory |
+| `/api/advise` | POST | loopback | LLM architectural advice (validates `base_url`) |
+| `/api/open` | POST | loopback | Open the native folder picker and switch project |
+| `/api/open-file` | POST | loopback | Open a graph node's file in the OS/IDE |
+
+## Security
+
+`archmap serve` is a developer tool, not a hardened multi-tenant service.
+
+- **Loopback by default.** Since v1.0.1 the server binds to `127.0.0.1`. Pass
+  `--host 0.0.0.0` to expose it on the network; a warning is printed when you do.
+- **State-changing and local endpoints are restricted to loopback** regardless
+  of `--host`. Endpoints that switch the analyzed directory, open local files, or
+  trigger outbound LLM requests (`/api/project`, `/api/reanalyze`, `/api/advise`,
+  `/api/open`, `/api/open-file`) reject non-loopback clients with `403`. Only the
+  read-only graph/health/badge endpoints are reachable when bound to `0.0.0.0`.
+- **`/api/advise` validates `base_url`** — only well-formed `http`/`https` URLs
+  are forwarded server-side, preventing SSRF via other URL schemes.
+
+For untrusted networks, keep the default loopback binding and put a reverse proxy
+with authentication in front if remote access is required.
 
 ## Notes
 
 - Press `Ctrl+C` to stop the server.
-- The UI `Refresh` button triggers `POST /api/reanalyze`, so restart is no longer required.
+- The UI `Refresh` button triggers `POST /api/reanalyze`, so a restart is not required.

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,7 +1,43 @@
 # Code of Conduct
 
-This project uses a standard contributor conduct policy.
+## Our Pledge
 
-Read the full document:
+We as members, contributors, and maintainers pledge to make participation in ArchMAP a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
 
-- https://github.com/Kaua-KGzin/ArchMAP/blob/main/CODE_OF_CONDUCT.md
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+**Examples of behavior that contributes to a positive environment:**
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+**Examples of unacceptable behavior:**
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and also applies when an individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening a GitHub issue or contacting the maintainer directly.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,15 +1,96 @@
-# Contributing
+# Contributing to ArchMAP
 
-## Quick checklist
+Thanks for contributing! Please read our [Code of Conduct](./code-of-conduct.md) first.
 
-1. Create branch from `dev` (`feat/*`, `fix/*`, or `docs/*`).
-2. Implement change with tests.
-3. Run:
-   - `python -m ruff check .`
-   - `python -m pytest -q`
-4. Update changelog/docs for behavior changes.
-5. Open PR to `dev` (or `release/*` during stabilization).
+## Prerequisites
 
-Full guide:
+- Python >= 3.11
+- pip >= 23
+- Git
 
-- https://github.com/Kaua-KGzin/ArchMAP/blob/main/CONTRIBUTING.md
+## Setup
+
+```bash
+git clone https://github.com/Kaua-KGzin/ArchMAP
+cd ArchMAP
+python -m pip install -e ".[dev]"
+```
+
+## Running the tool locally
+
+```bash
+# Analyze a project
+archmap analyze <path>
+
+# Start the interactive Web UI
+archmap serve <path>
+
+# Compare two git refs
+archmap diff HEAD~5 HEAD
+```
+
+## Running tests
+
+```bash
+pytest                       # all tests with coverage
+pytest tests/test_cli.py     # single module
+pytest -k "parser"           # filter by name
+```
+
+## Running lint
+
+```bash
+ruff check .
+```
+
+## Building the Windows executable (PyInstaller)
+
+```bash
+pip install pyinstaller
+pyinstaller archmap.spec
+# Output: dist/archmap.exe
+```
+
+## Branching model
+
+- `main`: stable branch only
+- `dev`: integration branch for upcoming release
+- `feat/*`: one feature per branch
+- `feature/*`: legacy alias supported
+- `fix/*`: bugfix branches
+- `docs/*`: documentation-only changes
+- `release/*`: stabilization and release prep
+
+Flow: `feat/* -> dev -> release/* -> main`
+
+## Development checklist before opening a PR
+
+1. Branch from `dev` (or `main` only for urgent production fixes).
+2. Implement changes with tests.
+3. Run quality gates:
+
+```bash
+ruff check .
+pytest
+archmap analyze . --format both --out .codeatlas/local-graph.json --out-mermaid .codeatlas/local-graph.mmd --include-cytoscape
+python -m archmap.cli.main analyze . --fail-on-risks
+```
+
+4. Update `CHANGELOG.md`, `README.md`, or `ROADMAP.md` if behavior changes.
+5. Open a PR using the repository template.
+
+## Coding guidelines
+
+- Keep modules focused and composable.
+- Prefer explicit data contracts for analyzer outputs (typed dicts).
+- Add tests for any parser/analyzer/exporter behavior changes.
+- Preserve CLI compatibility unless a major release justifies breaking changes.
+
+## Original distribution attribution
+
+ArchMAP is originally distributed by **Kaua Gabriel** (Kaua-KGzin).
+
+When redistributing source code or binaries, preserve:
+- `LICENSE`
+- `NOTICE.md`
+

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -8,8 +8,29 @@
 ## Install from PyPI
 
 ```bash
-pip install archmap
+pip install KG-ARCHMAP
 archmap version
+```
+
+## Optional: tree-sitter parsers
+
+ArchMAP works out of the box with regex-based parsers. For the most accurate
+analysis, install the optional `[tree-sitter]` extra, which enables real
+AST-based parsing for all 9 languages:
+
+```bash
+pip install "KG-ARCHMAP[tree-sitter]"
+```
+
+When installed, tree-sitter is used as a resilient **primary** parser — each
+grammar loads independently, and any file it cannot parse falls back to the regex
+path automatically (it is never dropped). Without the extra, the regex fallback is
+used and nothing breaks.
+
+## Docker
+
+```bash
+docker run -p 3000:3000 -v "$(pwd):/project" ghcr.io/kaua-kgzin/archmap
 ```
 
 ## Install for development

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,48 +1,31 @@
-<p align="center">
-  <img src="assets/logo.png" alt="ArchMAP" width="460"/>
-</p>
+<div class="archmap-hero" markdown>
 
 <p align="center">
-  <em>Map Your Architecture. Control Your Future.</em>
+  <img src="assets/logo.png" alt="ArchMAP" width="420"/>
 </p>
+
+<p class="tagline"><em>Map Your Architecture. Control Your Future.</em></p>
 
 <p align="center">
   <a href="https://github.com/Kaua-KGzin/ArchMAP/actions/workflows/ci.yml">
     <img src="https://github.com/Kaua-KGzin/ArchMAP/actions/workflows/ci.yml/badge.svg" alt="CI"/>
   </a>
-  <img src="https://img.shields.io/badge/version-1.0.0-brightgreen" alt="v1.0.0"/>
+  <img src="https://img.shields.io/badge/version-1.0.3-brightgreen" alt="v1.0.3"/>
   <img src="https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue" alt="Python"/>
   <img src="https://img.shields.io/badge/license-MIT-green" alt="MIT"/>
 </p>
 
+[Get started](getting-started/installation.md){ .md-button .md-button--primary }
+[CLI reference](cli/analyze.md){ .md-button }
+
+</div>
+
 ---
 
-**ArchMAP** is a static architecture analysis toolkit for source repositories.
-
-It parses code, builds dependency graphs, detects circular dependencies, computes complexity and risk signals, and exposes results through a rich CLI and an interactive web UI.
-
-## What's in v1.0.0
-
-| Feature | Command |
-|---|---|
-| Multi-language parsing (Python, JS/TS, Rust, Go, PHP, Java, C#, C/C++) | `archmap analyze` |
-| Circular dependency detection (Tarjan SCC) | `archmap analyze` |
-| Architecture risk scoring (god modules, layer violations, dep explosions) | `archmap risk` |
-| Git ref diff and JSON snapshot diff | `archmap diff` |
-| BFS reachability from any entrypoint | `archmap trace` |
-| Temporal coupling analysis via git log | `archmap temporal` |
-| LLM architectural advisor — Claude, OpenAI, Ollama, or any local model | `archmap advise` |
-| MCP server for Claude Code / Cursor / Windsurf integration | `archmap mcp` |
-| Exporters: JSON, Mermaid, Cytoscape, SARIF | `archmap analyze` |
-| Interactive service map with PNG + SVG export | `archmap serve` |
-| Stable public Python API (`from archmap import analyze_project`) | library |
-| VS Code extension with inline diagnostics and health score | IDE |
-
-## Getting started
-
-<p align="center">
-  <img src="assets/banner-cli.png" alt="archmap CLI" width="520"/>
-</p>
+**ArchMAP** is a static architecture analysis toolkit for source repositories. It
+parses code, builds dependency graphs, detects circular dependencies, computes
+complexity and risk signals, and exposes the results through a rich CLI, an
+interactive web UI, and an MCP server for AI assistants.
 
 ```bash
 pip install KG-ARCHMAP
@@ -50,8 +33,56 @@ archmap analyze . --format both
 archmap serve .
 ```
 
-1. [Installation](getting-started/installation.md)
-2. [Quick Start](getting-started/quickstart.md)
+## Why ArchMAP
+
+<div class="grid cards" markdown>
+
+-   :material-graph-outline:{ .lg .middle } __Dependency graphs, 9 languages__
+
+    ---
+
+    Python, JavaScript, TypeScript, Rust, Go, PHP, Java, C#, and C/C++. Tree-sitter
+    is used as a resilient primary parser with an automatic per-file regex fallback.
+
+    [:octicons-arrow-right-24: Architecture](architecture.md)
+
+-   :material-sync-circle:{ .lg .middle } __Cycle & risk detection__
+
+    ---
+
+    Strongly-connected-component cycle detection, god-module / layer-violation /
+    dependency-explosion smells, and a composite risk score per file.
+
+    [:octicons-arrow-right-24: Risk command](cli/risk.md)
+
+-   :material-shield-check:{ .lg .middle } __CI quality gates__
+
+    ---
+
+    Fail the build on cycles, architectural risks, coupling budgets, or a low
+    import-resolution rate. SARIF export integrates with GitHub Code Scanning.
+
+    [:octicons-arrow-right-24: Analyze command](cli/analyze.md)
+
+-   :material-robot-outline:{ .lg .middle } __AI-native__
+
+    ---
+
+    An MCP server exposes the analysis engine to Claude Code, Cursor, and Windsurf,
+    plus an optional LLM architectural advisor.
+
+    [:octicons-arrow-right-24: MCP server](cli/mcp.md)
+
+</div>
+
+## Getting started
+
+<p align="center">
+  <img src="assets/banner-cli.png" alt="archmap CLI" width="520"/>
+</p>
+
+1. [Installation](getting-started/installation.md) — PyPI, Docker, and the optional tree-sitter extra
+2. [Quick Start](getting-started/quickstart.md) — analyze and serve your first project
 3. [Live Demo](getting-started/demo.md)
 
 ## CLI reference
@@ -65,21 +96,30 @@ archmap serve .
 | [`serve`](cli/serve.md) | Interactive web UI with graph, insights, trace, advisor |
 | [`diff`](cli/diff.md) | Compare git refs or JSON snapshots |
 | [`trace`](cli/trace.md) | BFS reachability from any entrypoint |
-| [`init`](cli/init.md) | Generate `.archmap.toml` from real dependency graph |
+| [`init`](cli/init.md) | Generate `.archmap.toml` from a real dependency graph |
 | [`advise`](cli/advise.md) | LLM-powered architectural advisor |
 | [`temporal`](cli/temporal.md) | Temporal coupling via git history |
 | [`mcp`](cli/mcp.md) | MCP server for AI assistant integration |
 | [`watch`](cli/watch.md) | Continuous analysis on file change |
+
+## What's new in 1.0.x
+
+- **1.0.3** — tree-sitter becomes a resilient *primary* parser with automatic
+  per-file fallback to the regex path; structured C# extraction.
+- **1.0.2** — comment-aware parsing and configuration-aware resolution
+  (Go `replace`, PHP composer PSR-4, Java inner classes, C# aliases, C/C++ include dirs).
+- **1.0.1** — security hardening (`serve` binds to loopback by default),
+  O(V+E) impact analysis, and tsconfig/jsconfig path-alias resolution.
+
+See the full [Changelog](changelog.md) and [Roadmap](roadmap.md).
 
 ## Governance and release
 
 - [Branching Strategy](BRANCHING.md)
 - [Contributing Guide](contributing.md)
 - [Code of Conduct](code-of-conduct.md)
-- [Changelog](changelog.md)
-- [Roadmap](roadmap.md)
 
 ## Attribution
 
-Original distributor: **Kaua Gabriel / Kauã Gabriel** (Kaua-KGzin).  
+Original distributor: **Kaua Gabriel / Kauã Gabriel** (Kaua-KGzin).
 See [Original Distribution Notice](notice.md) and the [MIT License](https://github.com/Kaua-KGzin/ArchMAP/blob/main/LICENSE).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,5 +1,115 @@
-# Roadmap
+# ArchMAP Roadmap
 
-Planned milestones and priorities:
+## Released
 
-- https://github.com/Kaua-KGzin/ArchMAP/blob/main/ROADMAP.md
+### v1.0.3 (2026-06-11)
+- **Tree-sitter as resilient primary parser** — per-language grammar availability + automatic per-file fallback to regex (`try_extract`) when a parse fails or is unreliable (no more dropped files).
+- **Structured C# extraction** (aliases, `global using`, `static`) via typed AST nodes.
+- **CI tests both the AST and regex paths** (dedicated `tree-sitter` job).
+
+### v1.0.2 (2026-06-11)
+- **Parser accuracy** — comment-aware regex fallbacks (no more phantom imports from comments) across JS/TS, Java, C#, PHP, C/C++.
+- **Config-aware resolution** — Go `replace` directives, PHP composer PSR-4 autoload, Java inner classes, C# aliases + `global using`, C/C++ include-dir suffix matching.
+
+### v1.0.1 (2026-06-11)
+- **Security hardening** — `serve` binds to loopback by default; state-changing and local endpoints (`/api/project`, `/api/reanalyze`, `/api/advise`) gated to loopback; `/api/advise` validates `base_url` scheme.
+- **Impact analysis O(V·E) → O(V+E)** — shared backward-adjacency map + `deque` BFS.
+- **Bug fixes** — LLM advisor layer-violation field names; Mermaid label escaping.
+- **tsconfig/jsconfig `paths` + `baseUrl` resolution** for JS/TS imports (improves resolution rate).
+- **CI coverage gate** (`--cov-fail-under=85`); Dockerfile pinned to `python:3.13-slim`.
+
+### v1.0.0 (2026-05-25)
+- **`archmap temporal`** — temporal coupling analysis via `git log`. Detects files that change together, ranked by co-change frequency and coupling strength. `--min-commits`, `--top`, `--json` flags. Zero new deps.
+- **Web UI SVG export** — "SVG" button in canvas toolbar. Scalable vector download via `cy.svg({ full: true })`. Zero new deps.
+- **MCP server** (`archmap mcp`) — JSON-RPC 2.0 stdio server with 4 tools: `get_architecture_summary`, `get_file_context`, `impact_analysis`, `run_checks`. Works with Claude Code, Cursor, Windsurf.
+- **Stable Public Python API** — `from archmap import analyze_project, AnalysisResult` is stable and fully typed. Zero-breaking-change commitment for all 1.x.
+- **mypy strict enforcement** — 0 errors as blocking CI gate.
+- **Test coverage raised to 88%** — new tests for `reachability_analyzer`, `generic_parser`, `rust_parser`, `go_parser`, `temporal_analyzer`.
+
+### post-v0.9.0 (now in v1.0.0)
+- **Per-import unresolved tracking** — `importsTotal`, `importsResolved`, `unresolvedImports` per file; `metrics.unresolvedImports` in graph report.
+- **`--show-unresolved[=N]`** — list imports that failed to resolve (file + specifier).
+- **Coupling budgets** — `[analysis.budgets]` in `.archmap.toml` + `--fail-on-budget-violations` CI gate + `--max-outgoing-per-file` / `--max-incoming-per-file` CLI overrides.
+- **`--ignore-external`** — strip external package nodes and their edges; metrics recomputed on the filtered graph.
+- **`--summary-format {text,table,markdown}`** — flexible terminal summary output.
+- **SVG XSS fix** — health grade XML-escaped in `/api/badge` response.
+- **Web UI** — dedicated gear-icon Config button; logo restored to Graph view navigation.
+
+### v0.9.0
+- **Parser resolution rate** — `resolutionRate` metric in all reports. CLI warns when < 70%. `--min-resolution-rate PCT` gate for CI.
+- **Shell completion** — `archmap --print-completion bash|zsh|fish`. Install: `pip install archmap[completion]`.
+- **Web UI PNG export** — Download button in canvas toolbar, 2× scale, zero deps. ✅
+- **Docker image** — `ghcr.io/kaua-kgzin/archmap:latest` published automatically on each release via GitHub Actions. ✅
+- **i18n — 6 languages** — English, Português (Brasil), Español, Français, Deutsch, 中文 (简体). Instant switch, persisted.
+- **Config panel** — Interface/General/Graph/LLM Advisor/Scan Languages. All persisted in localStorage.
+- **LLM config persistence** — Provider, model, base URL, API key saved; auto-save mode.
+
+### v0.8.1
+- **`/api/badge`** — dynamic SVG health badge endpoint for README embedding (`GET /api/badge`).
+- **`/api/advise`** — server-side LLM advisor endpoint; Web UI AI Advisor panel now has an interactive form with Ollama/Claude/OpenAI/custom provider support.
+
+### v0.8.0
+- **`archmap trace <entrypoint>`** — BFS reachability from any file: dependency tree by depth, coverage %, `--unreachable`, `--max-depth`.
+- **`archmap advise`** — LLM-powered architectural advisor supporting Claude, OpenAI, Ollama, and any OpenAI-compatible local endpoint (LM Studio, etc.) — zero new runtime deps.
+- **`archmap init --from-analysis`** — derives `.archmap.toml` layer rules from the actual dependency graph (not just directory names).
+- **`archmap diff --snapshot-a/--snapshot-b`** — compare two saved JSON snapshots without git refs.
+- **VS Code extension** (`vscode-extension/`) — inline diagnostics, health score status bar, trace webview, web UI launcher.
+- **Web UI — Trace view**: BFS client-side with depth-colored graph highlight and coverage stats.
+- **Web UI — AI Advisor view**: top issue cards and CLI command reference per provider.
+
+### v0.7.2
+- Web UI multi-view navigation: nav rail (Graph/Insights/Rules & Layers), Layer Diagram tab, Dependency Matrix tab.
+
+### v0.7.1
+- Web UI complete visual refresh (Inter + JetBrains Mono, indigo design system, health gauge, KPI tiles).
+- Cytoscape bundled locally — removes CDN dependency and fixes CSP.
+- CI fixes for Windows EXE build and PyPI trusted publisher.
+
+### v0.7.0
+- TypeScript parser with triple-slash reference support.
+- Reusable GitHub Action (`action.yml`) with SARIF upload.
+- Pre-commit hook via `archmap-check` entrypoint.
+- Incremental parse cache — unchanged files skipped on re-analysis.
+- `--sarif` flag for SARIF 2.1.0 export.
+
+### v0.6.x
+- Security hardening: subprocess timeouts, path traversal guards, CSP headers.
+- Windows-safe CLI output and broader parser stability.
+- Professional open-source governance (SECURITY.md, CODEOWNERS, py.typed).
+
+---
+
+## Medium-term (v1.0.0)
+
+- **Public Python API** — Define and document a stable programmatic surface (`from archmap import analyze_project, ArchMapConfig, AnalysisResult`). Add `__all__` to public modules, document with MkDocs examples, establish a deprecation policy (`DeprecationWarning` + semver). Unlocks IDE plugins, pytest integrations, and custom CI tooling beyond the CLI.
+- **mypy enforcement (blocking)** — Graduate mypy from non-blocking (infrastructure only, v0.8.x) to a hard CI gate. Expand typed coverage module by module until `--strict` is feasible on the full `src/archmap/` tree.
+- **Version bump to v1.0.0** — Finalize the public API contract, write a migration guide from 0.x, and tag the first stable release.
+
+---
+
+## Longer-term
+
+- Plugin SDK for custom parsers and analyzers via entry points.
+- Change coupling detector via `git log` analysis.
+- Multi-repo topology support.
+- WebSocket-based live UI refresh.
+- GraphML and Graphviz DOT export formats.
+- **Tree-sitter based parsers** — ✅ Done. Optional `[tree-sitter]` extra ships AST-based parsers for all 9 languages; regex fallback preserved when the extra is not installed.
+- **Property-based testing (Hypothesis)** — Add `hypothesis` to dev deps and use it on all language parsers. The parser must never crash on any valid unicode input.
+- **Mutation testing (mutmut)** — Apply mutation testing to core analysis modules (`cycle_detector.py`, `risk_analyzer.py`, `complexity_analyzer.py`).
+- **Homebrew formula** — Distribute as a Homebrew tap for macOS users (`brew install kaua-kgzin/tap/archmap`).
+- **Web UI accessibility (a11y)** — Audit and fix WCAG 2.1 AA compliance: color contrast, keyboard navigation, focus management, ARIA labels for the Cytoscape.js graph.
+- **SVG export** — Add a "Download SVG" button using Cytoscape.js's `cy.svg()` API.
+- **API stability policy** — Publish a formal versioning contract: public vs. internal modules, deprecation timeline.
+
+---
+
+## Continuous
+
+These are ongoing commitments rather than versioned deliverables. They run in parallel with every release cycle.
+
+- **Supply chain audit** — `pip-audit` runs in CI on every push (implemented in v0.8.x). Dependabot watches Python deps, npm deps, and GitHub Actions pins on a weekly schedule. No manual audit cadence required.
+- **Architectural self-check (dogfooding)** — CI runs `archmap analyze src/archmap/ --fail-on-cycles` on every push. ArchMAP must pass its own analysis. The health score threshold (`--min-health`) is raised incrementally as the codebase improves, making the gate self-tightening.
+- **mypy coverage expansion** — Type annotations are added incrementally to every new or modified file. The mypy CI step starts non-blocking (infrastructure, v0.8.x) and transitions to a hard gate (v0.9.x) once baseline coverage is established. No new untyped functions merged after v0.9.0.
+- **Documentation freshness** — Every CLI flag, JSON output field, and `.archmap.toml` key introduced in a PR must be documented in the same PR. The MkDocs build runs with `--strict` in CI; broken references fail the docs workflow.
+- **Parser parity** — As new language features are introduced (e.g., Python 3.12+ type parameter syntax, TypeScript 5.x satisfies operator), parser regression tests are added before the parser update is merged. No silent parser regressions.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,27 +1,197 @@
-/* ArchMAP brand colors — navy #0d1b2e + orange #e87230 */
+/* ============================================================================
+   ArchMAP documentation theme
+   Brand: navy #0d1b2e + orange #e87230
+   ========================================================================== */
+
+:root {
+  --archmap-navy: #0d1b2e;
+  --archmap-navy-soft: #14253c;
+  --archmap-orange: #e87230;
+  --archmap-orange-soft: #f09050;
+  --md-default-fg-color--lightest: rgba(13, 27, 46, 0.04);
+}
 
 [data-md-color-scheme="default"] {
   --md-primary-fg-color:              #0d1b2e;
   --md-primary-fg-color--light:       #1e3a5f;
   --md-primary-fg-color--dark:        #060d17;
   --md-primary-bg-color:              #ffffff;
-  --md-primary-bg-color--light:       rgba(255,255,255,0.7);
+  --md-primary-bg-color--light:       rgba(255, 255, 255, 0.7);
   --md-accent-fg-color:               #e87230;
-  --md-accent-fg-color--transparent:  rgba(232,114,48,0.1);
+  --md-accent-fg-color--transparent:  rgba(232, 114, 48, 0.1);
   --md-accent-bg-color:               #ffffff;
+  --md-typeset-a-color:               #c0571a;
 }
 
 [data-md-color-scheme="slate"] {
-  --md-primary-fg-color:              #e87230;
-  --md-primary-fg-color--light:       #f09050;
-  --md-primary-fg-color--dark:        #c05818;
-  --md-primary-bg-color:              #0d1b2e;
+  --md-primary-fg-color:              #0d1b2e;
+  --md-primary-fg-color--light:       #1e3a5f;
+  --md-primary-fg-color--dark:        #060d17;
+  --md-primary-bg-color:              #ffffff;
   --md-accent-fg-color:               #e87230;
-  --md-accent-fg-color--transparent:  rgba(232,114,48,0.1);
+  --md-accent-fg-color--transparent:  rgba(232, 114, 48, 0.12);
+  --md-typeset-a-color:               #f09050;
+  --md-default-bg-color:              #0a1320;
+  --md-default-bg-color--light:       #0d1b2e;
 }
 
-/* Nav logo sizing */
+/* --- Header / nav polish ------------------------------------------------- */
+
+.md-header {
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.06);
+  backdrop-filter: saturate(1.2);
+}
+
 .md-header__button.md-logo img {
   height: 2rem;
   width: auto;
+}
+
+.md-tabs {
+  background: linear-gradient(90deg, var(--archmap-navy) 0%, var(--archmap-navy-soft) 100%);
+}
+
+[data-md-color-scheme="slate"] .md-tabs {
+  background: linear-gradient(90deg, #060d17 0%, var(--archmap-navy) 100%);
+}
+
+/* --- Typography ---------------------------------------------------------- */
+
+.md-typeset h1 {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.md-typeset h2 {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin-top: 2.2em;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.md-typeset h3 {
+  font-weight: 600;
+}
+
+/* --- Links --------------------------------------------------------------- */
+
+.md-typeset a {
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.15s ease;
+}
+
+.md-typeset a:hover {
+  border-bottom-color: var(--md-accent-fg-color);
+}
+
+/* --- Code blocks --------------------------------------------------------- */
+
+.md-typeset pre > code {
+  border-radius: 8px;
+}
+
+.md-typeset .highlight {
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(13, 27, 46, 0.06);
+}
+
+.md-typeset code {
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+/* --- Tables -------------------------------------------------------------- */
+
+.md-typeset table:not([class]) {
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(13, 27, 46, 0.08);
+  border: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.md-typeset table:not([class]) th {
+  background: var(--archmap-navy);
+  color: #fff;
+  font-weight: 600;
+}
+
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) th {
+  background: #060d17;
+}
+
+.md-typeset table:not([class]) tr:hover {
+  background: var(--md-accent-fg-color--transparent);
+}
+
+/* --- Buttons ------------------------------------------------------------- */
+
+.md-typeset .md-button {
+  border-radius: 6px;
+  font-weight: 600;
+  transition: transform 0.1s ease, box-shadow 0.15s ease;
+}
+
+.md-typeset .md-button--primary {
+  background: var(--archmap-orange);
+  border-color: var(--archmap-orange);
+  color: #fff;
+}
+
+.md-typeset .md-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(232, 114, 48, 0.3);
+}
+
+/* --- Grid cards (homepage + feature grids) ------------------------------- */
+
+.md-typeset .grid.cards > ul > li,
+.md-typeset .grid.cards > :is(ul, ol) > li {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 10px;
+  padding: 1rem 1.1rem;
+  transition: transform 0.12s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.md-typeset .grid.cards > ul > li:hover {
+  transform: translateY(-3px);
+  border-color: var(--archmap-orange);
+  box-shadow: 0 8px 24px rgba(13, 27, 46, 0.1);
+}
+
+.md-typeset .grid.cards .twemoji,
+.md-typeset .grid.cards .emojione {
+  color: var(--archmap-orange);
+}
+
+/* --- Admonitions: brand the "tip" / "note" accents ----------------------- */
+
+.md-typeset .admonition,
+.md-typeset details {
+  border-radius: 8px;
+  border-left-width: 3px;
+}
+
+/* --- Homepage hero ------------------------------------------------------- */
+
+.archmap-hero {
+  text-align: center;
+  padding: 1.5rem 0 0.5rem;
+}
+
+.archmap-hero .tagline {
+  font-size: 1.15rem;
+  color: var(--md-default-fg-color--light);
+  margin: 0.2rem 0 1rem;
+}
+
+/* --- Footer -------------------------------------------------------------- */
+
+.md-footer {
+  background: var(--archmap-navy);
+}
+
+.md-footer-meta {
+  background: #060d17;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,29 +10,46 @@ theme:
   logo: assets/logo-nav.png
   favicon: assets/favicon.png
   palette:
-    - scheme: default
+    - media: "(prefers-color-scheme)"
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
       primary: custom
       accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    - scheme: slate
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       primary: custom
       accent: custom
       toggle:
         icon: material/brightness-4
-        name: Switch to light mode
+        name: Switch to system preference
   features:
     - navigation.tabs
+    - navigation.tabs.sticky
     - navigation.sections
     - navigation.top
+    - navigation.tracking
     - navigation.indexes
+    - navigation.footer
+    - toc.follow
     - search.highlight
     - search.suggest
+    - search.share
     - content.code.copy
     - content.code.annotate
+    - content.tooltips
   icon:
     repo: fontawesome/brands/github
+  font:
+    text: Inter
+    code: JetBrains Mono
 
 extra_css:
   - stylesheets/extra.css
@@ -71,6 +88,8 @@ nav:
       - trace: cli/trace.md
       - init: cli/init.md
       - advise: cli/advise.md
+      - temporal: cli/temporal.md
+      - mcp: cli/mcp.md
       - watch: cli/watch.md
   - Internals:
       - Architecture: architecture.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archmap",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Static architecture analysis and visualization for software projects — dependency graphs, cycle detection, risk scoring, LLM advisor.",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archmap",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Static architecture analysis and visualization for software projects — dependency graphs, cycle detection, risk scoring, LLM advisor.",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archmap",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Static architecture analysis and visualization for software projects — dependency graphs, cycle detection, risk scoring, LLM advisor.",
   "private": true,
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ packages = ["src/archmap"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-q --cov=archmap --cov-report=term-missing"
+addopts = "-q --cov=archmap --cov-report=term-missing --cov-fail-under=85"
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/archmap/__init__.py
+++ b/src/archmap/__init__.py
@@ -38,7 +38,7 @@ from archmap.types import (
     UnresolvedImportEntry,
 )
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 
 def analyze_project(

--- a/src/archmap/__init__.py
+++ b/src/archmap/__init__.py
@@ -38,7 +38,7 @@ from archmap.types import (
     UnresolvedImportEntry,
 )
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 
 def analyze_project(

--- a/src/archmap/__init__.py
+++ b/src/archmap/__init__.py
@@ -38,7 +38,7 @@ from archmap.types import (
     UnresolvedImportEntry,
 )
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 
 def analyze_project(

--- a/src/archmap/cli/commands.py
+++ b/src/archmap/cli/commands.py
@@ -34,6 +34,7 @@ from archmap.cli.reporting import (
 )
 from archmap.cli.server import (
     ReportState,
+    _is_loopback_host,
     browser_host,
     build_http_handler,
     can_open_browser,
@@ -202,6 +203,13 @@ def run_serve(args: argparse.Namespace) -> int:
     print(f"[info] Web UI available at {browser_url}")
     if bind_url != browser_url:
         print(f"[info] Listening on {bind_url}")
+    if not _is_loopback_host(args.host):
+        print(
+            f"[warn] Server bound to {args.host}: reachable from other hosts on the "
+            "network. Local-only endpoints (open file, switch project, advise) stay "
+            "restricted to loopback, but anyone who can reach this port can read the "
+            "dependency graph. Use --host 127.0.0.1 if that is not intended."
+        )
     print("[info] Press Ctrl+C to stop.")
     try:
         server.serve_forever()

--- a/src/archmap/cli/defaults.py
+++ b/src/archmap/cli/defaults.py
@@ -5,5 +5,8 @@ DEFAULT_MERMAID_OUTPUT_PATH = ".codeatlas/graph.mmd"
 DEFAULT_CYTOSCAPE_OUTPUT_PATH = ".codeatlas/graph-cytoscape.json"
 DEFAULT_SARIF_OUTPUT_PATH = ".codeatlas/archmap.sarif"
 DEFAULT_PORT = 3000
-DEFAULT_HOST = "0.0.0.0"
+# Bind to loopback by default. The serve command exposes endpoints that switch
+# the analyzed directory and trigger outbound LLM calls; binding to 0.0.0.0
+# would expose those to anyone on the network. Opt in explicitly with --host.
+DEFAULT_HOST = "127.0.0.1"
 DEFAULT_TOP_ITEMS = 5

--- a/src/archmap/cli/server.py
+++ b/src/archmap/cli/server.py
@@ -90,35 +90,29 @@ def build_http_handler(state: ReportState, static_dir: Path) -> type[SimpleHTTPR
         def _is_local_request(self) -> bool:
             return self.client_address[0] in {"127.0.0.1", "::1", "localhost"}
 
+        # All POST endpoints mutate server state, read local files, switch the
+        # analyzed directory, or trigger outbound LLM requests. None of these
+        # are safe to expose to other hosts, so every one is gated to loopback.
+        _LOCAL_ONLY_POST = {
+            "/api/advise": "_handle_advise",
+            "/api/open": "_handle_open_project",
+            "/api/open-file": "_handle_open_file",
+            "/api/project": "_handle_set_project",
+            "/api/reanalyze": "_handle_reanalyze",
+        }
+
         def do_POST(self):  # noqa: N802
-            if self.path == "/api/advise":
-                self._handle_advise()
+            handler_name = self._LOCAL_ONLY_POST.get(self.path)
+            if handler_name is None:
+                self.send_error(HTTPStatus.NOT_FOUND)
                 return
-            if self.path == "/api/open":
-                if not self._is_local_request():
-                    self._write_json(
-                        HTTPStatus.FORBIDDEN,
-                        {"status": "error", "message": "only available on localhost"},
-                    )
-                    return
-                self._handle_open_project()
+            if not self._is_local_request():
+                self._write_json(
+                    HTTPStatus.FORBIDDEN,
+                    {"status": "error", "message": "only available on localhost"},
+                )
                 return
-            if self.path == "/api/open-file":
-                if not self._is_local_request():
-                    self._write_json(
-                        HTTPStatus.FORBIDDEN,
-                        {"status": "error", "message": "only available on localhost"},
-                    )
-                    return
-                self._handle_open_file()
-                return
-            if self.path == "/api/project":
-                self._handle_set_project()
-                return
-            if self.path == "/api/reanalyze":
-                self._handle_reanalyze()
-                return
-            self.send_error(HTTPStatus.NOT_FOUND)
+            getattr(self, handler_name)()
 
         def do_GET(self):  # noqa: N802
             parsed_url = urlsplit(self.path)
@@ -417,6 +411,15 @@ def build_http_handler(state: ReportState, static_dir: Path) -> type[SimpleHTTPR
 
             model = payload.get("model") or None
             base_url = payload.get("base_url") or None
+            if base_url is not None and not _is_safe_base_url(str(base_url)):
+                self._write_json(
+                    HTTPStatus.BAD_REQUEST,
+                    {
+                        "status": "error",
+                        "message": "base_url must be an http(s) URL",
+                    },
+                )
+                return
             api_key = payload.get("api_key") or None
             try:
                 timeout = int(payload.get("timeout") or 90)
@@ -451,6 +454,20 @@ def build_http_handler(state: ReportState, static_dir: Path) -> type[SimpleHTTPR
             return
 
     return Handler
+
+
+def _is_safe_base_url(base_url: str) -> bool:
+    """Reject anything that is not a well-formed http(s) URL.
+
+    The advise endpoint POSTs the report to ``base_url`` server-side, so a
+    non-http scheme (file://, gopher://, …) or a malformed value must never be
+    forwarded to ``urllib``.
+    """
+    candidate = base_url.strip()
+    if not candidate:
+        return False
+    parts = urlsplit(candidate)
+    return parts.scheme in {"http", "https"} and bool(parts.netloc)
 
 
 def _describe_directory_picker_error(exc: Exception) -> str:
@@ -605,3 +622,7 @@ def browser_host(host: str) -> str:
     if host in {"0.0.0.0", "::"}:
         return "localhost"
     return host
+
+
+def _is_loopback_host(host: str) -> bool:
+    return host in {"localhost", "127.0.0.1", "::1"}

--- a/src/archmap/core/advisor/llm_advisor.py
+++ b/src/archmap/core/advisor/llm_advisor.py
@@ -88,7 +88,7 @@ def _build_prompt(report: dict) -> str:
             d.get("file") for d in risks.get("dependency_explosions", [])[:5]
         ],
         "layer_violations": [
-            f"{v.get('fromLayer')} -> {v.get('toLayer')}: {v.get('file')}"
+            f"{v.get('sourceLayer')} -> {v.get('targetLayer')}: {v.get('source')}"
             for v in risks.get("layer_violations", [])[:5]
         ],
         "rule_violations": [

--- a/src/archmap/core/analyzer/dependency_graph.py
+++ b/src/archmap/core/analyzer/dependency_graph.py
@@ -9,7 +9,7 @@ from archmap.core.analyzer.complexity_analyzer import (
 )
 from archmap.core.analyzer.cycle_detector import enrich_cycles, find_circular_dependencies
 from archmap.core.analyzer.human_analyzer import analyze_human
-from archmap.core.analyzer.impact_analyzer import calculate_impact
+from archmap.core.analyzer.impact_analyzer import build_dependents_map, calculate_impact
 from archmap.core.analyzer.project_explainer import explain_project
 from archmap.core.analyzer.risk_analyzer import detect_architectural_risks
 
@@ -30,8 +30,9 @@ def analyze_graph(
     nodes = annotate_nodes_with_complexity(graph["nodes"], cycle_membership)
     edges = _annotate_edges(graph["edges"], cycle_membership)
 
+    dependents_map = build_dependents_map(edges)
     for node in nodes:
-        node["impact"] = calculate_impact(node["id"], edges)
+        node["impact"] = calculate_impact(node["id"], edges, dependents_map)
 
     incoming_counts = {node["id"]: int(node.get("incoming", 0)) for node in nodes}
     enriched = enrich_cycles(cycles, adjacency, incoming_counts)

--- a/src/archmap/core/analyzer/impact_analyzer.py
+++ b/src/archmap/core/analyzer/impact_analyzer.py
@@ -1,21 +1,41 @@
 from __future__ import annotations
 
+from collections import deque
 
-def calculate_impact(node_id: str, edges: list[dict]) -> dict:
-    # Build backward adjacency list (target -> list of sources)
-    # If source depends on target, target impacts source.
+
+def build_dependents_map(edges: list[dict]) -> dict[str, list[str]]:
+    """Build a backward adjacency map (target -> sources that depend on it).
+
+    Computing this once and reusing it across every node turns whole-graph
+    impact analysis from O(V * E) into O(V + E).  If ``source`` depends on
+    ``target``, then ``target`` impacts ``source``.
+    """
     dependents_map: dict[str, list[str]] = {}
     for edge in edges:
-        source = edge["source"]
-        target = edge["target"]
-        dependents_map.setdefault(target, []).append(source)
+        dependents_map.setdefault(edge["target"], []).append(edge["source"])
+    return dependents_map
 
-    impacted = set()
-    queue = [node_id]
+
+def calculate_impact(
+    node_id: str,
+    edges: list[dict],
+    dependents_map: dict[str, list[str]] | None = None,
+) -> dict:
+    """Return the transitive set of files impacted by a change to ``node_id``.
+
+    ``dependents_map`` may be supplied (via :func:`build_dependents_map`) to
+    avoid rebuilding the backward adjacency on every call; when omitted it is
+    derived from ``edges`` for backward compatibility.
+    """
+    if dependents_map is None:
+        dependents_map = build_dependents_map(edges)
+
+    impacted: set[str] = set()
     visited = {node_id}
+    queue: deque[str] = deque([node_id])
 
     while queue:
-        current = queue.pop(0)
+        current = queue.popleft()
         for dependent in dependents_map.get(current, []):
             if dependent not in visited:
                 visited.add(dependent)
@@ -33,7 +53,7 @@ def calculate_impact(node_id: str, edges: list[dict]) -> dict:
 
     return {
         "nodeId": node_id,
-        "impactedFiles": sorted(list(impacted)),
+        "impactedFiles": sorted(impacted),
         "impactCount": count,
-        "risk": risk
+        "risk": risk,
     }

--- a/src/archmap/core/parser/__init__.py
+++ b/src/archmap/core/parser/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
 import posixpath
+import re
+from collections.abc import Callable
 from pathlib import Path, PurePosixPath
 from typing import Any, NotRequired, TypedDict
 
@@ -203,8 +206,148 @@ def _resolve_dependencies(
     return []
 
 
+class TsconfigAliases(TypedDict):
+    """Resolved tsconfig/jsconfig module-resolution settings."""
+
+    base_url: str
+    paths: dict[str, list[str]]
+
+
+def _strip_jsonc(text: str) -> str:
+    """Remove // and /* */ comments and trailing commas from a JSONC document.
+
+    tsconfig.json is JSON-with-comments; ``json.loads`` rejects both comments
+    and trailing commas, so we sanitise them while preserving string contents.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    in_string = False
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "/":
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "*":
+            i += 2
+            while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        out.append(ch)
+        i += 1
+    sanitised = "".join(out)
+    # Drop trailing commas before } or ]
+    return re.sub(r",(\s*[}\]])", r"\1", sanitised)
+
+
+def _load_tsconfig_aliases(
+    get_file_content: Callable[[str], str | None] | None,
+) -> TsconfigAliases | None:
+    """Read tsconfig.json / jsconfig.json and extract baseUrl + paths aliases."""
+    if get_file_content is None:
+        return None
+
+    raw = None
+    for name in ("tsconfig.json", "jsconfig.json"):
+        raw = get_file_content(name)
+        if raw:
+            break
+    if not raw:
+        return None
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        try:
+            data = json.loads(_strip_jsonc(raw))
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(data, dict):
+        return None
+
+    compiler_options = data.get("compilerOptions")
+    if not isinstance(compiler_options, dict):
+        return None
+
+    base_url = compiler_options.get("baseUrl")
+    base_url = base_url if isinstance(base_url, str) else ""
+
+    raw_paths = compiler_options.get("paths")
+    paths: dict[str, list[str]] = {}
+    if isinstance(raw_paths, dict):
+        for alias, targets in raw_paths.items():
+            if not isinstance(alias, str) or not isinstance(targets, list):
+                continue
+            string_targets = [t for t in targets if isinstance(t, str)]
+            if string_targets:
+                paths[alias] = string_targets
+
+    if not base_url and not paths:
+        return None
+    return {"base_url": base_url, "paths": paths}
+
+
+def _resolve_alias_specifier(
+    specifier: str, aliases: TsconfigAliases, file_ids: set[str]
+) -> Dependency | None:
+    """Resolve a bare specifier against tsconfig paths/baseUrl, if possible."""
+    base_url = aliases["base_url"].strip("/")
+
+    def _try(candidate: str) -> Dependency | None:
+        normalized = normalize_file_id(candidate.lstrip("/"))
+        if not normalized:
+            return None
+        match = _find_matching_file(normalized, JS_TS_RESOLUTION_EXTENSIONS, file_ids)
+        return _make_file_dependency(match) if match else None
+
+    # paths aliases take precedence (e.g. "@app/*": ["src/*"])
+    for alias, targets in aliases["paths"].items():
+        for target in targets:
+            if alias.endswith("*") and target.endswith("*"):
+                prefix = alias[:-1]
+                if specifier.startswith(prefix):
+                    tail = specifier[len(prefix):]
+                    mapped = target[:-1] + tail
+                    candidate = posixpath.join(base_url, mapped) if base_url else mapped
+                    dep = _try(candidate)
+                    if dep:
+                        return dep
+            elif alias == specifier:
+                candidate = posixpath.join(base_url, target) if base_url else target
+                dep = _try(candidate)
+                if dep:
+                    return dep
+
+    # baseUrl-relative resolution for non-aliased bare specifiers
+    if base_url:
+        dep = _try(posixpath.join(base_url, specifier))
+        if dep:
+            return dep
+    return None
+
+
 def _resolve_js_ts_dependency(
-    specifier: str, file_id: str, file_ids: set[str]
+    specifier: str,
+    file_id: str,
+    file_ids: set[str],
+    aliases: TsconfigAliases | None = None,
 ) -> Dependency | None:
     if specifier.startswith(".") or specifier.startswith("/"):
         if specifier.startswith("/"):
@@ -220,6 +363,11 @@ def _resolve_js_ts_dependency(
         if match:
             return _make_file_dependency(match)
         return None
+
+    if aliases is not None:
+        alias_dep = _resolve_alias_specifier(specifier, aliases, file_ids)
+        if alias_dep:
+            return alias_dep
 
     package_name = _extract_package_name(specifier)
     if package_name:

--- a/src/archmap/core/parser/_text.py
+++ b/src/archmap/core/parser/_text.py
@@ -1,0 +1,86 @@
+"""Shared text-preprocessing helpers for the regex parser fallbacks.
+
+The regex fallbacks (used when the optional tree-sitter extra is not installed)
+historically matched import-like text inside comments, which produced false
+dependencies. ``strip_comments`` removes comments while staying inside string
+literals, so genuine specifiers embedded in strings (``require("x")``,
+``#include "x"``) are preserved. Newlines are kept intact so that
+``re.MULTILINE`` anchors keep working on the cleaned source.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def strip_comments(
+    source: str,
+    *,
+    line_comments: Sequence[str] = ("//",),
+    block_comments: Sequence[tuple[str, str]] = (("/*", "*/"),),
+    string_delims: Sequence[str] = ('"', "'"),
+) -> str:
+    """Return ``source`` with comments blanked out (replaced by spaces).
+
+    Comment characters are replaced with spaces rather than removed so that
+    byte offsets and, more importantly, line counts are preserved. The scanner
+    is string-aware: ``//`` inside ``"http://..."`` is not treated as a comment.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(source)
+    active_string: str | None = None
+
+    while i < n:
+        ch = source[i]
+
+        if active_string is not None:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out.append(source[i + 1])
+                i += 2
+                continue
+            if ch == active_string:
+                active_string = None
+            i += 1
+            continue
+
+        # Entering a string literal
+        if ch in string_delims:
+            active_string = ch
+            out.append(ch)
+            i += 1
+            continue
+
+        # Block comments
+        matched_block = False
+        for opener, closer in block_comments:
+            if source.startswith(opener, i):
+                end = source.find(closer, i + len(opener))
+                if end == -1:
+                    end = n
+                else:
+                    end += len(closer)
+                for j in range(i, end):
+                    out.append("\n" if source[j] == "\n" else " ")
+                i = end
+                matched_block = True
+                break
+        if matched_block:
+            continue
+
+        # Line comments
+        matched_line = False
+        for marker in line_comments:
+            if source.startswith(marker, i):
+                while i < n and source[i] != "\n":
+                    out.append(" ")
+                    i += 1
+                matched_line = True
+                break
+        if matched_line:
+            continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)

--- a/src/archmap/core/parser/cpp_parser.py
+++ b/src/archmap/core/parser/cpp_parser.py
@@ -15,15 +15,11 @@ class CppImportEntry(TypedDict):
 
 
 def _parse_cpp_includes(source_code: str, cpp: bool = False) -> list[CppImportEntry]:
-    from archmap.core.parser.ts_engine import (  # noqa: PLC0415
-        HAS_TREE_SITTER,
-        extract_c_includes,
-        extract_cpp_includes,
-    )
+    from archmap.core.parser import ts_engine  # noqa: PLC0415
 
-    if HAS_TREE_SITTER:
-        fn = extract_cpp_includes if cpp else extract_c_includes
-        return fn(source_code)  # type: ignore[return-value]
+    ts_result = ts_engine.try_extract("cpp" if cpp else "c", source_code)
+    if ts_result is not None:
+        return ts_result
 
     from archmap.core.parser._text import strip_comments
 

--- a/src/archmap/core/parser/cpp_parser.py
+++ b/src/archmap/core/parser/cpp_parser.py
@@ -25,6 +25,11 @@ def _parse_cpp_includes(source_code: str, cpp: bool = False) -> list[CppImportEn
         fn = extract_cpp_includes if cpp else extract_c_includes
         return fn(source_code)  # type: ignore[return-value]
 
+    from archmap.core.parser._text import strip_comments
+
+    # `#` is a preprocessor directive in C/C++, not a comment, so only //-style
+    # and block comments are stripped. String delims kept so #include "x" stays.
+    source_code = strip_comments(source_code, line_comments=("//",))
     imports: list[CppImportEntry] = []
     for match in SYSTEM_INCLUDE_RE.finditer(source_code):
         imports.append({"type": "system", "value": match.group(1).strip()})

--- a/src/archmap/core/parser/csharp_parser.py
+++ b/src/archmap/core/parser/csharp_parser.py
@@ -18,10 +18,11 @@ class CSharpParser(ParserPlugin):
     extensions = [".cs"]
 
     def parse(self, source_code: str) -> list[str]:
-        from archmap.core.parser.ts_engine import HAS_TREE_SITTER, extract_csharp_imports
+        from archmap.core.parser import ts_engine
 
-        if HAS_TREE_SITTER:
-            return extract_csharp_imports(source_code)
+        ts_result = ts_engine.try_extract("csharp", source_code)
+        if ts_result is not None:
+            return ts_result
 
         from archmap.core.parser._text import strip_comments
 

--- a/src/archmap/core/parser/csharp_parser.py
+++ b/src/archmap/core/parser/csharp_parser.py
@@ -5,7 +5,12 @@ from typing import Any
 
 from archmap.core.parser.registry import Dependency, ParserPlugin
 
-CS_IMPORT_RE = re.compile(r"^\s*using\s+([^=;]+);", re.MULTILINE)
+# Captures `using X;`, `global using X;`, `using static X;` and the right-hand
+# side of alias directives `using Alias = Real.Namespace;`.
+CS_IMPORT_RE = re.compile(
+    r"^\s*(?:global\s+)?using\s+(?:static\s+)?(?:[A-Za-z_][\w.]*\s*=\s*)?([^;]+);",
+    re.MULTILINE,
+)
 
 
 class CSharpParser(ParserPlugin):
@@ -18,9 +23,16 @@ class CSharpParser(ParserPlugin):
         if HAS_TREE_SITTER:
             return extract_csharp_imports(source_code)
 
+        from archmap.core.parser._text import strip_comments
+
+        cleaned = strip_comments(source_code)
         imports: set[str] = set()
-        for match in CS_IMPORT_RE.finditer(source_code):
-            imports.add(match.group(1).strip())
+        for match in CS_IMPORT_RE.finditer(cleaned):
+            value = match.group(1).strip()
+            # Skip `using (var x = ...)` resource statements and aliases to a
+            # generic/type expression that are not namespace imports.
+            if value and "(" not in value and not value.startswith("var "):
+                imports.add(value)
         return sorted(imports)
 
     def resolve(

--- a/src/archmap/core/parser/go_parser.py
+++ b/src/archmap/core/parser/go_parser.py
@@ -24,10 +24,11 @@ class GoParser(ParserPlugin):
     extensions = [".go"]
 
     def parse(self, source_code: str) -> list[str]:
-        from archmap.core.parser.ts_engine import HAS_TREE_SITTER, extract_go_imports
+        from archmap.core.parser import ts_engine
 
-        if HAS_TREE_SITTER:
-            return extract_go_imports(source_code)
+        ts_result = ts_engine.try_extract("go", source_code)
+        if ts_result is not None:
+            return ts_result
 
         imports: set[str] = set()
 

--- a/src/archmap/core/parser/go_parser.py
+++ b/src/archmap/core/parser/go_parser.py
@@ -55,6 +55,7 @@ class GoParser(ParserPlugin):
         from archmap.core.parser.resolvers import _resolve_go_dependency
 
         module_name = None
+        replacements: dict[str, str] = {}
         get_file_content = kwargs.get("get_file_content")
         if get_file_content:
             mod_content = get_file_content("go.mod")
@@ -62,4 +63,32 @@ class GoParser(ParserPlugin):
                 match = re.search(r"^module\s+(.+)$", mod_content, re.MULTILINE)
                 if match:
                     module_name = match.group(1).strip()
-        return _resolve_go_dependency(import_entries, file_id, file_ids, module_name)
+                replacements = _parse_go_replacements(mod_content)
+        return _resolve_go_dependency(
+            import_entries, file_id, file_ids, module_name, replacements
+        )
+
+
+# Matches a single replace mapping, with optional version on either side:
+#   example.com/old => ./local
+#   example.com/old v1.2.3 => ../local v0.0.0
+_GO_REPLACE_RE = re.compile(
+    r"^\s*(?:replace\s+)?([^\s=]+)(?:\s+v[^\s]+)?\s*=>\s*([^\s]+)",
+    re.MULTILINE,
+)
+
+
+def _parse_go_replacements(mod_content: str) -> dict[str, str]:
+    """Return a map of replaced module path -> local target path.
+
+    Only local replacements (targets starting with ./ or ../) are kept; remote
+    replacements still resolve as external packages.
+    """
+    replacements: dict[str, str] = {}
+    for match in _GO_REPLACE_RE.finditer(mod_content):
+        old, target = match.group(1).strip(), match.group(2).strip()
+        if "=>" in old or not target:
+            continue
+        if target.startswith(("./", "../")):
+            replacements[old] = target
+    return replacements

--- a/src/archmap/core/parser/java_parser.py
+++ b/src/archmap/core/parser/java_parser.py
@@ -18,8 +18,11 @@ class JavaParser(ParserPlugin):
         if HAS_TREE_SITTER:
             return extract_java_imports(source_code)
 
+        from archmap.core.parser._text import strip_comments
+
+        cleaned = strip_comments(source_code)
         imports: set[str] = set()
-        for match in JAVA_IMPORT_RE.finditer(source_code):
+        for match in JAVA_IMPORT_RE.finditer(cleaned):
             imports.add(match.group(1).strip())
         return sorted(imports)
 

--- a/src/archmap/core/parser/java_parser.py
+++ b/src/archmap/core/parser/java_parser.py
@@ -13,10 +13,11 @@ class JavaParser(ParserPlugin):
     extensions = [".java"]
 
     def parse(self, source_code: str) -> list[str]:
-        from archmap.core.parser.ts_engine import HAS_TREE_SITTER, extract_java_imports
+        from archmap.core.parser import ts_engine
 
-        if HAS_TREE_SITTER:
-            return extract_java_imports(source_code)
+        ts_result = ts_engine.try_extract("java", source_code)
+        if ts_result is not None:
+            return ts_result
 
         from archmap.core.parser._text import strip_comments
 

--- a/src/archmap/core/parser/js_parser.py
+++ b/src/archmap/core/parser/js_parser.py
@@ -20,9 +20,12 @@ class JSParser(ParserPlugin):
         if HAS_TREE_SITTER:
             return extract_js_imports(source_code)
 
+        from archmap.core.parser._text import strip_comments
+
+        cleaned = strip_comments(source_code, string_delims=('"', "'", "`"))
         imports: set[str] = set()
         for pattern in (IMPORT_EXPORT_RE, REQUIRE_RE, DYNAMIC_IMPORT_RE):
-            for match in pattern.finditer(source_code):
+            for match in pattern.finditer(cleaned):
                 specifier = match.group(1).strip()
                 if specifier:
                     imports.add(specifier)

--- a/src/archmap/core/parser/js_parser.py
+++ b/src/archmap/core/parser/js_parser.py
@@ -14,12 +14,17 @@ class JSParser(ParserPlugin):
     language = "javascript"
     extensions = [".js", ".jsx", ".mjs", ".cjs"]
 
+    _TS_LANGUAGE = "javascript"
+
     def parse(self, source_code: str) -> list[str]:
-        from archmap.core.parser.ts_engine import HAS_TREE_SITTER, extract_js_imports
+        from archmap.core.parser import ts_engine
 
-        if HAS_TREE_SITTER:
-            return extract_js_imports(source_code)
+        ts_result = ts_engine.try_extract(self._TS_LANGUAGE, source_code)
+        if ts_result is not None:
+            return ts_result
+        return self._parse_with_regex(source_code)
 
+    def _parse_with_regex(self, source_code: str) -> list[str]:
         from archmap.core.parser._text import strip_comments
 
         cleaned = strip_comments(source_code, string_delims=('"', "'", "`"))

--- a/src/archmap/core/parser/js_parser.py
+++ b/src/archmap/core/parser/js_parser.py
@@ -31,12 +31,14 @@ class JSParser(ParserPlugin):
     def resolve(
         self, import_entries: list[Any], file_id: str, file_ids: set[str], **kwargs: Any
     ) -> list[Dependency]:
-        from archmap.core.parser import _resolve_js_ts_dependency
+        from archmap.core.parser import _load_tsconfig_aliases, _resolve_js_ts_dependency
+
+        aliases = _load_tsconfig_aliases(kwargs.get("get_file_content"))
 
         resolved: list[Dependency] = []
         for specifier in import_entries:
             if isinstance(specifier, str):
-                dep = _resolve_js_ts_dependency(specifier, file_id, file_ids)
+                dep = _resolve_js_ts_dependency(specifier, file_id, file_ids, aliases)
                 if dep:
                     resolved.append(dep)
         return resolved

--- a/src/archmap/core/parser/php_parser.py
+++ b/src/archmap/core/parser/php_parser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 from typing import Any, TypedDict
 
@@ -25,6 +26,11 @@ class PHPParser(ParserPlugin):
         if HAS_TREE_SITTER:
             return extract_php_imports(source_code)  # type: ignore[return-value]
 
+        from archmap.core.parser._text import strip_comments
+
+        source_code = strip_comments(
+            source_code, line_comments=("//", "#"), string_delims=('"', "'")
+        )
         imports: list[PHPImportEntry] = []
         for match in USE_RE.finditer(source_code):
             imports.append({"type": "use", "value": match.group(1).strip()})
@@ -43,9 +49,43 @@ class PHPParser(ParserPlugin):
     ) -> list[Dependency]:
         from archmap.core.parser.resolvers import _resolve_php_dependency
 
+        psr4 = _load_composer_psr4(kwargs.get("get_file_content"))
+
         resolved: list[Dependency] = []
         for entry in import_entries:
             if isinstance(entry, dict):
-                deps = _resolve_php_dependency(entry, file_id, file_ids)
+                deps = _resolve_php_dependency(entry, file_id, file_ids, psr4)
                 resolved.extend(deps)
         return resolved
+
+
+def _load_composer_psr4(get_file_content: Any) -> dict[str, list[str]]:
+    """Read composer.json and return its PSR-4 namespace -> directory map."""
+    if not get_file_content:
+        return {}
+    raw = get_file_content("composer.json")
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+
+    psr4: dict[str, list[str]] = {}
+    for section in ("autoload", "autoload-dev"):
+        block = data.get(section)
+        if not isinstance(block, dict):
+            continue
+        mapping = block.get("psr-4")
+        if not isinstance(mapping, dict):
+            continue
+        for prefix, target in mapping.items():
+            if not isinstance(prefix, str):
+                continue
+            dirs = target if isinstance(target, list) else [target]
+            string_dirs = [d for d in dirs if isinstance(d, str)]
+            if string_dirs:
+                psr4[prefix] = string_dirs
+    return psr4

--- a/src/archmap/core/parser/php_parser.py
+++ b/src/archmap/core/parser/php_parser.py
@@ -21,10 +21,11 @@ class PHPParser(ParserPlugin):
     extensions = [".php"]
 
     def parse(self, source_code: str) -> list[PHPImportEntry]:
-        from archmap.core.parser.ts_engine import HAS_TREE_SITTER, extract_php_imports
+        from archmap.core.parser import ts_engine
 
-        if HAS_TREE_SITTER:
-            return extract_php_imports(source_code)  # type: ignore[return-value]
+        ts_result = ts_engine.try_extract("php", source_code)
+        if ts_result is not None:
+            return ts_result
 
         from archmap.core.parser._text import strip_comments
 

--- a/src/archmap/core/parser/resolvers.py
+++ b/src/archmap/core/parser/resolvers.py
@@ -349,8 +349,21 @@ def _resolve_go_dependency(
     file_id: str,
     file_ids: set[str],
     module_name: str | None,
+    replacements: dict[str, str] | None = None,
 ) -> list[Dependency]:
     resolved: list[Dependency] = []
+    replacements = replacements or {}
+
+    def _collect_dir(package_dir: str) -> bool:
+        normalized_dir = normalize_file_id(package_dir).strip("/")
+        found = False
+        for fid in file_ids:
+            if normalize_file_id(posixpath.dirname(fid)) == normalized_dir and fid.endswith(
+                ".go"
+            ):
+                resolved.append(_make_file_dependency(fid))
+                found = True
+        return found
 
     for specifier in import_entries:
         if not isinstance(specifier, str) or not specifier:
@@ -358,23 +371,34 @@ def _resolve_go_dependency(
 
         if module_name and (specifier == module_name or specifier.startswith(module_name + "/")):
             package_dir = "" if specifier == module_name else specifier[len(module_name) + 1 :]
-
-            found_local = False
-            for fid in file_ids:
-                if posixpath.dirname(fid) == package_dir and fid.endswith(".go"):
-                    resolved.append(_make_file_dependency(fid))
-                    found_local = True
-
-            if found_local:
+            if _collect_dir(package_dir):
                 continue
+
+        # go.mod replace directive pointing at a local module path
+        replaced_dir = _match_go_replacement(specifier, replacements)
+        if replaced_dir is not None and _collect_dir(replaced_dir):
+            continue
 
         resolved.append(_make_package_dependency(specifier))
 
     return _dedupe_dependencies(resolved)
 
 
+def _match_go_replacement(specifier: str, replacements: dict[str, str]) -> str | None:
+    """Map an import path to a local directory via go.mod replace, if any."""
+    for old, target in replacements.items():
+        if specifier == old or specifier.startswith(old + "/"):
+            sub = "" if specifier == old else specifier[len(old) + 1 :]
+            local = target.removeprefix("./")
+            return _safe_norm_join(local, sub) if sub else _safe_norm_join(local)
+    return None
+
+
 def _resolve_php_dependency(
-    import_entry: Mapping[str, Any], file_id: str, file_ids: set[str]
+    import_entry: Mapping[str, Any],
+    file_id: str,
+    file_ids: set[str],
+    psr4: dict[str, list[str]] | None = None,
 ) -> list[Dependency]:
     entry_type = import_entry.get("type")
     value = str(import_entry.get("value", "")).strip()
@@ -393,6 +417,11 @@ def _resolve_php_dependency(
         return [_make_package_dependency(value)]
 
     if entry_type == "use":
+        # composer PSR-4 autoload takes precedence over heuristic suffix matching.
+        psr4_match = _resolve_php_psr4(value, psr4 or {}, file_ids)
+        if psr4_match:
+            return [_make_file_dependency(psr4_match)]
+
         path_candidate = normalize_file_id(value.replace("\\", "/"))
 
         parts = path_candidate.split("/")
@@ -414,6 +443,34 @@ def _resolve_php_dependency(
         return [_make_package_dependency(value)]
 
     return []
+
+
+def _resolve_php_psr4(
+    namespace: str, psr4: dict[str, list[str]], file_ids: set[str]
+) -> str | None:
+    """Resolve a PHP namespace via composer PSR-4 autoload prefixes.
+
+    e.g. with {"App\\": "src/"}, ``App\\Models\\User`` -> ``src/Models/User.php``.
+    Longest matching prefix wins, as PSR-4 mandates.
+    """
+    if not psr4:
+        return None
+
+    norm_ns = namespace.lstrip("\\")
+    for prefix in sorted(psr4, key=len, reverse=True):
+        clean_prefix = prefix.rstrip("\\")
+        if clean_prefix and not (
+            norm_ns == clean_prefix or norm_ns.startswith(clean_prefix + "\\")
+        ):
+            continue
+        remainder = norm_ns[len(clean_prefix):].lstrip("\\") if clean_prefix else norm_ns
+        sub_path = remainder.replace("\\", "/")
+        for base_dir in psr4[prefix]:
+            candidate = _safe_norm_join(normalize_file_id(base_dir.rstrip("/")), sub_path)
+            match = _find_php_module(candidate, file_ids)
+            if match:
+                return match
+    return None
 
 
 def _find_php_module(base_candidate: str, file_ids: set[str]) -> str | None:
@@ -449,12 +506,15 @@ def _resolve_java_dependency(
             return resolved
         return [_make_package_dependency(specifier)]
 
-    path_candidate = normalize_file_id(specifier.replace(".", "/")) + ".java"
-    normalized_candidate = path_candidate.casefold()
-
-    for fid in file_ids:
-        if fid.casefold().endswith(normalized_candidate):
-            return [_make_file_dependency(fid)]
+    segments = specifier.split(".")
+    # Try the full path first, then progressively treat trailing segments as
+    # inner classes: `com.example.Outer.Inner` may live in `com/example/Outer.java`.
+    for cut in range(len(segments), 1, -1):
+        path_candidate = normalize_file_id("/".join(segments[:cut])) + ".java"
+        normalized_candidate = path_candidate.casefold()
+        for fid in file_ids:
+            if fid.casefold().endswith(normalized_candidate):
+                return [_make_file_dependency(fid)]
 
     return [_make_package_dependency(specifier)]
 
@@ -481,6 +541,14 @@ def _resolve_cpp_dependency(
         absolute_candidate = normalize_file_id(value)
         if absolute_candidate in file_ids:
             return [_make_file_dependency(absolute_candidate)]
+
+        # Fallback for projects that compile with -I include dirs: a header
+        # included as "foo/bar.h" frequently lives at include/foo/bar.h or
+        # src/foo/bar.h. Match by unique path suffix.
+        suffix = "/" + absolute_candidate
+        suffix_matches = [fid for fid in file_ids if fid.endswith(suffix)]
+        if len(suffix_matches) == 1:
+            return [_make_file_dependency(suffix_matches[0])]
 
         return [_make_package_dependency(value)]
 

--- a/src/archmap/core/parser/rust_parser.py
+++ b/src/archmap/core/parser/rust_parser.py
@@ -19,11 +19,15 @@ class RustParser(ParserPlugin):
     extensions = [".rs"]
 
     def parse(self, source_code: str) -> list[RustImportEntry]:
-        from archmap.core.parser.ts_engine import HAS_TREE_SITTER, extract_rust_imports
+        from archmap.core.parser import ts_engine
 
-        if HAS_TREE_SITTER:
-            return extract_rust_imports(source_code)  # type: ignore[return-value]
+        ts_result = ts_engine.try_extract("rust", source_code)
+        if ts_result is not None:
+            return ts_result
 
+        from archmap.core.parser._text import strip_comments
+
+        source_code = strip_comments(source_code)
         dependencies: list[RustImportEntry] = []
         for match in USE_RE.finditer(source_code):
             normalized = _normalize_use_path(match.group(1))

--- a/src/archmap/core/parser/ts_engine.py
+++ b/src/archmap/core/parser/ts_engine.py
@@ -1,47 +1,101 @@
 """Tree-sitter engine for multi-language import extraction.
 
-Falls back gracefully when tree-sitter is not installed.
-Install the optional extra to enable: pip install archmap[tree-sitter]
+Design goals (v1.0.3):
+
+- **Per-language availability.** Each grammar loads independently. If, say,
+  ``tree-sitter-php`` is missing or fails to load, PHP transparently uses its
+  regex fallback while every other language still benefits from tree-sitter.
+- **Automatic per-file fallback.** ``try_extract`` is the entry point used by
+  the parsers. It returns ``None`` whenever tree-sitter cannot be trusted for a
+  given file — grammar unavailable, an exception during parse/query, or a parse
+  that contains syntax errors *and* yielded no imports — so the caller switches
+  to the regex path for that single file instead of dropping it.
+- **Structured extraction.** Specifiers are read from typed AST nodes rather
+  than by slicing the matched text, so aliases, ``global using``, ``static``,
+  multiline imports, and string/comment noise are handled correctly.
+
+Install the optional extra to enable: ``pip install archmap[tree-sitter]``.
 """
 from __future__ import annotations
 
+import logging
 import re as _re
+from collections.abc import Callable
+from typing import Any
 
-HAS_TREE_SITTER = False
+logger = logging.getLogger(__name__)
+
+# Populated lazily below: language name -> compiled tree_sitter.Language.
+_LANGUAGES: dict[str, Any] = {}
+# language name -> compiled Query objects (built once, on first availability).
+_QUERIES: dict[str, Any] = {}
+
+_Language: Any = None
+_Parser: Any = None
+_Query: Any = None
+_QueryCursor: Any = None
 
 try:
-    import tree_sitter_c as _tsc_lang
-    import tree_sitter_c_sharp as _tscs
-    import tree_sitter_cpp as _tscpp
-    import tree_sitter_go as _tsgo
-    import tree_sitter_java as _tsjava_lang
-    import tree_sitter_javascript as _tsjava
-    import tree_sitter_php as _tsphp
-    import tree_sitter_rust as _tsrust
-    import tree_sitter_typescript as _tsts
     from tree_sitter import Language, Parser, Query, QueryCursor
 
-    _JS_LANGUAGE = Language(_tsjava.language())
-    _TS_LANGUAGE = Language(_tsts.language_typescript())
-    _TSX_LANGUAGE = Language(_tsts.language_tsx())
-    _JAVA_LANGUAGE = Language(_tsjava_lang.language())
-    _GO_LANGUAGE = Language(_tsgo.language())
-    _RUST_LANGUAGE = Language(_tsrust.language())
-    _PHP_LANGUAGE = Language(_tsphp.language_php())
-    _CS_LANGUAGE = Language(_tscs.language())
-    _C_LANGUAGE = Language(_tsc_lang.language())
-    _CPP_LANGUAGE = Language(_tscpp.language())
-    HAS_TREE_SITTER = True
-except (ImportError, AttributeError):
-    pass
+    _Language, _Parser, _Query, _QueryCursor = Language, Parser, Query, QueryCursor
+    _TS_CORE_AVAILABLE = True
+except ImportError:
+    _TS_CORE_AVAILABLE = False
+
+
+# Each grammar is imported in isolation: one missing wheel does not disable the
+# rest. ``language_constructor`` returns the raw grammar pointer.
+_GRAMMAR_LOADERS: dict[str, tuple[str, str]] = {
+    "javascript": ("tree_sitter_javascript", "language"),
+    "typescript": ("tree_sitter_typescript", "language_typescript"),
+    "tsx": ("tree_sitter_typescript", "language_tsx"),
+    "java": ("tree_sitter_java", "language"),
+    "go": ("tree_sitter_go", "language"),
+    "rust": ("tree_sitter_rust", "language"),
+    "php": ("tree_sitter_php", "language_php"),
+    "csharp": ("tree_sitter_c_sharp", "language"),
+    "c": ("tree_sitter_c", "language"),
+    "cpp": ("tree_sitter_cpp", "language"),
+}
+
+
+def _load_language(name: str) -> Any | None:
+    if not _TS_CORE_AVAILABLE:
+        return None
+    if name in _LANGUAGES:
+        return _LANGUAGES[name]
+    spec = _GRAMMAR_LOADERS.get(name)
+    if spec is None:
+        return None
+    module_name, attr = spec
+    try:
+        module = __import__(module_name)
+        language = _Language(getattr(module, attr)())
+    except (ImportError, AttributeError, ValueError, TypeError) as exc:
+        logger.debug("tree-sitter grammar %s unavailable: %s", name, exc)
+        return None
+    _LANGUAGES[name] = language
+    return language
+
+
+def language_available(name: str) -> bool:
+    """Return True if a usable tree-sitter grammar is loaded for ``name``."""
+    return _load_language(name) is not None
+
+
+# Eagerly probe every grammar so HAS_TREE_SITTER reflects real availability and
+# query objects are built once up front (cheaper than per-call).
+for _lang_name in _GRAMMAR_LOADERS:
+    _load_language(_lang_name)
+
+HAS_TREE_SITTER = bool(_LANGUAGES)
 
 
 # ---------------------------------------------------------------------------
 # Query strings
 # ---------------------------------------------------------------------------
 
-# JS/TS: ESM import/export-from, require(), dynamic import()
-# @_fn is an auxiliary capture used only by the #eq? predicate.
 _JS_QUERY_SRC = """
 (import_statement source: (string (string_fragment) @specifier))
 (export_statement source: (string (string_fragment) @specifier))
@@ -65,9 +119,6 @@ _RUST_MOD_QUERY_SRC = "(mod_item name: (identifier) @name)"
 _RUST_EXTERN_QUERY_SRC = "(extern_crate_declaration name: (identifier) @name)"
 
 _PHP_USE_QUERY_SRC = "(namespace_use_declaration) @decl"
-# Capture the expression node; string content is extracted in Python to handle
-# both single-quoted (string) and double-quoted (encapsed_string) PHP strings
-# as well as the parenthesized call form: require('x') vs require 'x'.
 _PHP_REQUIRE_QUERY_SRC = "[(require_expression) @req (require_once_expression) @req]"
 _PHP_INCLUDE_QUERY_SRC = "[(include_expression) @inc (include_once_expression) @inc]"
 
@@ -75,56 +126,54 @@ _CS_QUERY_SRC = "(using_directive) @decl"
 
 _INCLUDE_QUERY_SRC = "(preproc_include) @inc"
 
-if HAS_TREE_SITTER:
-    _JS_QUERY = Query(_JS_LANGUAGE, _JS_QUERY_SRC)
-    _TS_QUERY = Query(_TS_LANGUAGE, _JS_QUERY_SRC)
-    _TSX_QUERY = Query(_TSX_LANGUAGE, _JS_QUERY_SRC)
-    _JAVA_QUERY = Query(_JAVA_LANGUAGE, _JAVA_QUERY_SRC)
-    _GO_QUERY = Query(_GO_LANGUAGE, _GO_QUERY_SRC)
-    _RUST_USE_QUERY = Query(_RUST_LANGUAGE, _RUST_USE_QUERY_SRC)
-    _RUST_MOD_QUERY = Query(_RUST_LANGUAGE, _RUST_MOD_QUERY_SRC)
-    _RUST_EXTERN_QUERY = Query(_RUST_LANGUAGE, _RUST_EXTERN_QUERY_SRC)
-    _PHP_USE_QUERY = Query(_PHP_LANGUAGE, _PHP_USE_QUERY_SRC)
-    _PHP_REQUIRE_QUERY = Query(_PHP_LANGUAGE, _PHP_REQUIRE_QUERY_SRC)
-    _PHP_INCLUDE_QUERY = Query(_PHP_LANGUAGE, _PHP_INCLUDE_QUERY_SRC)
-    _CS_QUERY = Query(_CS_LANGUAGE, _CS_QUERY_SRC)
-    _C_INCLUDE_QUERY = Query(_C_LANGUAGE, _INCLUDE_QUERY_SRC)
-    _CPP_INCLUDE_QUERY = Query(_CPP_LANGUAGE, _INCLUDE_QUERY_SRC)
+
+def _query(language_name: str, key: str, source: str) -> Any | None:
+    """Lazily compile and cache a Query for a language."""
+    cache_key = f"{language_name}:{key}"
+    if cache_key in _QUERIES:
+        return _QUERIES[cache_key]
+    language = _load_language(language_name)
+    if language is None:
+        return None
+    try:
+        compiled = _Query(language, source)
+    except Exception as exc:  # noqa: BLE001 - grammar/query mismatch -> fall back
+        logger.debug("tree-sitter query compile failed for %s/%s: %s", language_name, key, exc)
+        _QUERIES[cache_key] = None
+        return None
+    _QUERIES[cache_key] = compiled
+    return compiled
 
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-def _captures(query: Query, tree: object) -> dict[str, list]:
+def _captures(query: Any, tree: Any) -> dict[str, list]:
     """Run a query and return captures sorted by document position."""
-    cursor = QueryCursor(query)
-    raw = cursor.captures(tree.root_node)  # type: ignore[attr-defined]
+    cursor = _QueryCursor(query)
+    raw = cursor.captures(tree.root_node)
     if isinstance(raw, dict):
-        # tree-sitter 0.24+ returns dict[str, list[Node]].
-        # The internal ordering is not guaranteed to be document order, so sort.
         return {
             k: sorted(v, key=lambda n: (n.start_point.row, n.start_point.column))
             for k, v in raw.items()
         }
-    # Older versions return list[tuple[Node, str]] — already in document order.
     result: dict[str, list] = {}
     for node, name in raw:
         result.setdefault(name, []).append(node)
     return result
 
 
-def _parse(language: Language, source_code: str) -> object:
-    return Parser(language).parse(source_code.encode("utf-8"))
+def _parse(language: Any, source_code: str) -> Any:
+    return _Parser(language).parse(source_code.encode("utf-8"))
 
 
-def _text(node: object) -> str:
+def _text(node: Any) -> str:
     raw = getattr(node, "text", None)
     return raw.decode("utf-8") if raw else ""
 
 
-def _find_string_content(node: object) -> str | None:
-    """Recursively find the first string_content node in a subtree."""
+def _find_string_content(node: Any) -> str | None:
     if getattr(node, "type", "") == "string_content":
         return _text(node)
     for child in getattr(node, "named_children", []):
@@ -134,43 +183,42 @@ def _find_string_content(node: object) -> str | None:
     return None
 
 
+def _last_name_node(node: Any) -> Any | None:
+    """Return the last identifier/qualified-name child (the real namespace).
+
+    For ``using Alias = Real.Ns;`` the alias identifier comes first and the
+    namespace second, so the last name node is the import target.
+    """
+    name_types = {"identifier", "qualified_name", "alias_qualified_name"}
+    chosen = None
+    for child in getattr(node, "named_children", []):
+        if getattr(child, "type", "") in name_types:
+            chosen = child
+    return chosen
+
+
 # ---------------------------------------------------------------------------
-# JavaScript / TypeScript
+# Per-language extraction from an already-parsed tree
 # ---------------------------------------------------------------------------
 
-def extract_js_imports(source_code: str) -> list[str]:
-    """Parse JavaScript and return sorted, deduplicated import specifiers."""
-    tree = _parse(_JS_LANGUAGE, source_code)
-    return _collect_specifiers(_captures(_JS_QUERY, tree))
-
-
-def extract_ts_imports(source_code: str, tsx: bool = False) -> list[str]:
-    """Parse TypeScript and return sorted, deduplicated import specifiers."""
-    lang = _TSX_LANGUAGE if tsx else _TS_LANGUAGE
-    query = _TSX_QUERY if tsx else _TS_QUERY
-    tree = _parse(lang, source_code)
-    return _collect_specifiers(_captures(query, tree))
-
-
-def _collect_specifiers(caps: dict) -> list[str]:
+def _extract_js_from_tree(tree: Any, language_name: str) -> list[str]:
+    query = _query(language_name, "imports", _JS_QUERY_SRC)
+    if query is None:
+        return []
     specifiers: set[str] = set()
-    for node in caps.get("specifier", []):
+    for node in _captures(query, tree).get("specifier", []):
         val = _text(node)
         if val:
             specifiers.add(val)
     return sorted(specifiers)
 
 
-# ---------------------------------------------------------------------------
-# Java
-# ---------------------------------------------------------------------------
-
-def extract_java_imports(source_code: str) -> list[str]:
-    """Parse Java and return sorted, deduplicated import strings."""
-    tree = _parse(_JAVA_LANGUAGE, source_code)
+def _extract_java_from_tree(tree: Any) -> list[str]:
+    query = _query("java", "imports", _JAVA_QUERY_SRC)
+    if query is None:
+        return []
     results: set[str] = set()
-    for node in _captures(_JAVA_QUERY, tree).get("decl", []):
-        # "import static org.junit.Assert.assertEquals;" → "org.junit.Assert.assertEquals"
+    for node in _captures(query, tree).get("decl", []):
         raw = _text(node).strip().removeprefix("import ").removeprefix("static ")
         val = raw.removesuffix(";").strip()
         if val:
@@ -178,45 +226,38 @@ def extract_java_imports(source_code: str) -> list[str]:
     return sorted(results)
 
 
-# ---------------------------------------------------------------------------
-# Go
-# ---------------------------------------------------------------------------
-
-def extract_go_imports(source_code: str) -> list[str]:
-    """Parse Go and return sorted, deduplicated import paths."""
-    tree = _parse(_GO_LANGUAGE, source_code)
+def _extract_go_from_tree(tree: Any) -> list[str]:
+    query = _query("go", "imports", _GO_QUERY_SRC)
+    if query is None:
+        return []
     results: set[str] = set()
-    for node in _captures(_GO_QUERY, tree).get("path", []):
+    for node in _captures(query, tree).get("path", []):
         val = _text(node)
         if val:
             results.add(val)
     return sorted(results)
 
 
-# ---------------------------------------------------------------------------
-# Rust
-# ---------------------------------------------------------------------------
-
-def extract_rust_imports(source_code: str) -> list[dict]:
-    """Parse Rust and return import entries compatible with RustImportEntry."""
-    tree = _parse(_RUST_LANGUAGE, source_code)
+def _extract_rust_from_tree(tree: Any) -> list[dict]:
     results: list[dict] = []
-
-    for node in _captures(_RUST_USE_QUERY, tree).get("arg", []):
-        normalized = _normalize_rust_use(_text(node))
-        if normalized:
-            results.append({"type": "use", "path": normalized, "module": "", "crate": ""})
-
-    for node in _captures(_RUST_MOD_QUERY, tree).get("name", []):
-        val = _text(node)
-        if val:
-            results.append({"type": "mod", "path": "", "module": val, "crate": ""})
-
-    for node in _captures(_RUST_EXTERN_QUERY, tree).get("name", []):
-        val = _text(node)
-        if val:
-            results.append({"type": "extern", "path": "", "module": "", "crate": val})
-
+    use_q = _query("rust", "use", _RUST_USE_QUERY_SRC)
+    mod_q = _query("rust", "mod", _RUST_MOD_QUERY_SRC)
+    extern_q = _query("rust", "extern", _RUST_EXTERN_QUERY_SRC)
+    if use_q is not None:
+        for node in _captures(use_q, tree).get("arg", []):
+            normalized = _normalize_rust_use(_text(node))
+            if normalized:
+                results.append({"type": "use", "path": normalized, "module": "", "crate": ""})
+    if mod_q is not None:
+        for node in _captures(mod_q, tree).get("name", []):
+            val = _text(node)
+            if val:
+                results.append({"type": "mod", "path": "", "module": val, "crate": ""})
+    if extern_q is not None:
+        for node in _captures(extern_q, tree).get("name", []):
+            val = _text(node)
+            if val:
+                results.append({"type": "extern", "path": "", "module": "", "crate": val})
     return results
 
 
@@ -228,70 +269,53 @@ def _normalize_rust_use(raw_path: str) -> str:
     return without_wildcard.removesuffix("::").strip()
 
 
-# ---------------------------------------------------------------------------
-# PHP
-# ---------------------------------------------------------------------------
-
-def extract_php_imports(source_code: str) -> list[dict]:
-    """Parse PHP and return import entries compatible with PHPImportEntry."""
-    tree = _parse(_PHP_LANGUAGE, source_code)
+def _extract_php_from_tree(tree: Any) -> list[dict]:
     results: list[dict] = []
-
-    for node in _captures(_PHP_USE_QUERY, tree).get("decl", []):
-        val = _text(node).strip().removeprefix("use ").removesuffix(";").strip()
-        if val:
-            results.append({"type": "use", "value": val})
-
-    for node in _captures(_PHP_REQUIRE_QUERY, tree).get("req", []):
-        val_r: str | None = _find_string_content(node)
-        if val_r:
-            results.append({"type": "require", "value": val_r})
-
-    for node in _captures(_PHP_INCLUDE_QUERY, tree).get("inc", []):
-        val_i: str | None = _find_string_content(node)
-        if val_i:
-            results.append({"type": "include", "value": val_i})
-
+    use_q = _query("php", "use", _PHP_USE_QUERY_SRC)
+    req_q = _query("php", "require", _PHP_REQUIRE_QUERY_SRC)
+    inc_q = _query("php", "include", _PHP_INCLUDE_QUERY_SRC)
+    if use_q is not None:
+        for node in _captures(use_q, tree).get("decl", []):
+            val = _text(node).strip().removeprefix("use ").removesuffix(";").strip()
+            if val:
+                results.append({"type": "use", "value": val})
+    if req_q is not None:
+        for node in _captures(req_q, tree).get("req", []):
+            val_r = _find_string_content(node)
+            if val_r:
+                results.append({"type": "require", "value": val_r})
+    if inc_q is not None:
+        for node in _captures(inc_q, tree).get("inc", []):
+            val_i = _find_string_content(node)
+            if val_i:
+                results.append({"type": "include", "value": val_i})
     return results
 
 
-# ---------------------------------------------------------------------------
-# C#
-# ---------------------------------------------------------------------------
-
-def extract_csharp_imports(source_code: str) -> list[str]:
-    """Parse C# and return sorted, deduplicated using namespace strings."""
-    tree = _parse(_CS_LANGUAGE, source_code)
+def _extract_csharp_from_tree(tree: Any) -> list[str]:
+    query = _query("csharp", "imports", _CS_QUERY_SRC)
+    if query is None:
+        return []
     results: set[str] = set()
-    for node in _captures(_CS_QUERY, tree).get("decl", []):
-        val = _text(node).strip().removeprefix("using ").removesuffix(";").strip()
+    for node in _captures(query, tree).get("decl", []):
+        name_node = _last_name_node(node)
+        # Skip `using (var x = ...)` resource statements (no name child).
+        val = _text(name_node).strip() if name_node is not None else ""
         if val:
             results.add(val)
     return sorted(results)
 
 
-# ---------------------------------------------------------------------------
-# C / C++
-# ---------------------------------------------------------------------------
-
-def extract_c_includes(source_code: str) -> list[dict]:
-    """Parse C and return include entries compatible with CppImportEntry."""
-    return _extract_includes(_C_LANGUAGE, _C_INCLUDE_QUERY, source_code)
-
-
-def extract_cpp_includes(source_code: str) -> list[dict]:
-    """Parse C++ and return include entries compatible with CppImportEntry."""
-    return _extract_includes(_CPP_LANGUAGE, _CPP_INCLUDE_QUERY, source_code)
-
-
-def _extract_includes(language: Language, query: Query, source_code: str) -> list[dict]:
-    tree = _parse(language, source_code)
+def _extract_includes_from_tree(tree: Any, language_name: str) -> list[dict]:
+    query = _query(language_name, "include", _INCLUDE_QUERY_SRC)
+    if query is None:
+        return []
     results: list[dict] = []
     for inc_node in _captures(query, tree).get("inc", []):
         for child in inc_node.children:
             if getattr(child, "type", "") == "system_lib_string":
                 raw = _text(child)
-                results.append({"type": "system", "value": raw[1:-1]})  # strip < >
+                results.append({"type": "system", "value": raw[1:-1]})
                 break
             if getattr(child, "type", "") == "string_literal":
                 inner = next(
@@ -305,3 +329,99 @@ def _extract_includes(language: Language, query: Query, source_code: str) -> lis
                 results.append({"type": "local", "value": inner})
                 break
     return results
+
+
+# ---------------------------------------------------------------------------
+# Orchestration: parse + reliability check + automatic fallback
+# ---------------------------------------------------------------------------
+
+# language name -> (grammar key, extractor taking (tree, grammar_name)).
+_EXTRACTORS: dict[str, tuple[str, Callable[[Any, str], Any]]] = {
+    "javascript": ("javascript", lambda t, n: _extract_js_from_tree(t, "javascript")),
+    "typescript": ("typescript", lambda t, n: _extract_js_from_tree(t, "typescript")),
+    "tsx": ("tsx", lambda t, n: _extract_js_from_tree(t, "tsx")),
+    "java": ("java", lambda t, n: _extract_java_from_tree(t)),
+    "go": ("go", lambda t, n: _extract_go_from_tree(t)),
+    "rust": ("rust", lambda t, n: _extract_rust_from_tree(t)),
+    "php": ("php", lambda t, n: _extract_php_from_tree(t)),
+    "csharp": ("csharp", lambda t, n: _extract_csharp_from_tree(t)),
+    "c": ("c", lambda t, n: _extract_includes_from_tree(t, "c")),
+    "cpp": ("cpp", lambda t, n: _extract_includes_from_tree(t, "cpp")),
+}
+
+
+def try_extract(language: str, source_code: str) -> Any | None:
+    """Extract imports via tree-sitter, or return ``None`` to request fallback.
+
+    ``None`` is returned when tree-sitter must not be trusted for this file:
+    the grammar is unavailable, parsing/querying raised, or the source has
+    syntax errors *and* no imports were recovered. In every other case the
+    structured tree-sitter result is returned (possibly an empty list, which is
+    a legitimate "no imports" answer for a cleanly-parsed file).
+    """
+    spec = _EXTRACTORS.get(language)
+    if spec is None:
+        return None
+    grammar_name, extractor = spec
+    grammar = _load_language(grammar_name)
+    if grammar is None:
+        return None
+
+    try:
+        tree = _parse(grammar, source_code)
+        entries = extractor(tree, grammar_name)
+    except Exception as exc:  # noqa: BLE001 - any failure -> regex fallback
+        logger.debug("tree-sitter extraction failed for %s: %s", language, exc)
+        return None
+
+    # A parse with errors that recovered nothing is unreliable: let the
+    # comment-aware regex fallback try instead of silently losing imports.
+    if not entries and _tree_has_error(tree):
+        return None
+    return entries
+
+
+def _tree_has_error(tree: Any) -> bool:
+    root = getattr(tree, "root_node", None)
+    return bool(getattr(root, "has_error", False)) if root is not None else False
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compatible public extractors (used directly by tests)
+# ---------------------------------------------------------------------------
+
+def extract_js_imports(source_code: str) -> list[str]:
+    return _extract_js_from_tree(_parse(_load_language("javascript"), source_code), "javascript")
+
+
+def extract_ts_imports(source_code: str, tsx: bool = False) -> list[str]:
+    name = "tsx" if tsx else "typescript"
+    return _extract_js_from_tree(_parse(_load_language(name), source_code), name)
+
+
+def extract_java_imports(source_code: str) -> list[str]:
+    return _extract_java_from_tree(_parse(_load_language("java"), source_code))
+
+
+def extract_go_imports(source_code: str) -> list[str]:
+    return _extract_go_from_tree(_parse(_load_language("go"), source_code))
+
+
+def extract_rust_imports(source_code: str) -> list[dict]:
+    return _extract_rust_from_tree(_parse(_load_language("rust"), source_code))
+
+
+def extract_php_imports(source_code: str) -> list[dict]:
+    return _extract_php_from_tree(_parse(_load_language("php"), source_code))
+
+
+def extract_csharp_imports(source_code: str) -> list[str]:
+    return _extract_csharp_from_tree(_parse(_load_language("csharp"), source_code))
+
+
+def extract_c_includes(source_code: str) -> list[dict]:
+    return _extract_includes_from_tree(_parse(_load_language("c"), source_code), "c")
+
+
+def extract_cpp_includes(source_code: str) -> list[dict]:
+    return _extract_includes_from_tree(_parse(_load_language("cpp"), source_code), "cpp")

--- a/src/archmap/core/parser/ts_parser.py
+++ b/src/archmap/core/parser/ts_parser.py
@@ -22,16 +22,18 @@ class TSParser(JSParser):
 
     language = "typescript"
     extensions = [".ts", ".tsx", ".mts", ".cts"]
+    # Use the TypeScript grammar directly rather than the JS grammar inherited
+    # from JSParser — avoids misclassification of TS-specific syntax.
+    _TS_LANGUAGE = "typescript"
 
     def parse(self, source_code: str) -> list[str]:
-        from archmap.core.parser.ts_engine import HAS_TREE_SITTER, extract_ts_imports
+        from archmap.core.parser import ts_engine
 
-        if HAS_TREE_SITTER:
-            # Use the TypeScript grammar directly rather than the JS grammar
-            # inherited from JSParser — avoids misclassification of TS-specific syntax.
-            imports = set(extract_ts_imports(source_code))
+        ts_result = ts_engine.try_extract(self._TS_LANGUAGE, source_code)
+        if ts_result is not None:
+            imports = set(ts_result)
         else:
-            imports = set(super().parse(source_code))
+            imports = set(self._parse_with_regex(source_code))
 
         imports.update(self._parse_triple_slash_refs(source_code))
         return sorted(imports)

--- a/src/archmap/exporters/mermaid_exporter.py
+++ b/src/archmap/exporters/mermaid_exporter.py
@@ -90,4 +90,13 @@ def _infer_node_type(node_id: str) -> str:
 
 
 def _to_mermaid_label(label: str) -> str:
-    return str(label).replace('"', '\\"')
+    # Wrap in quotes at the call site is implicit; escape characters that would
+    # otherwise break Mermaid node syntax. Backslash must be escaped first so we
+    # do not double-escape the sequences introduced below.
+    escaped = str(label).replace("\\", "\\\\")
+    escaped = escaped.replace('"', "&quot;")
+    escaped = escaped.replace("\n", " ").replace("\r", " ")
+    escaped = escaped.replace("[", "(").replace("]", ")")
+    escaped = escaped.replace("{", "(").replace("}", ")")
+    escaped = escaped.replace("<", "&lt;").replace(">", "&gt;")
+    return f'"{escaped}"'

--- a/tests/test_csharp_parser.py
+++ b/tests/test_csharp_parser.py
@@ -21,12 +21,13 @@ def test_csharp_parser_regex_extraction() -> None:
     parser = CSharpParser()
     imports = parser.parse(source)
 
+    # `static` is consumed as a directive prefix; the namespace itself is kept.
     assert imports == [
         "MyApp.Core.Services",
         "MyApp.Models",
         "System",
         "System.Collections.Generic",
-        "static System.Math",
+        "System.Math",
     ]
 
 

--- a/tests/test_parser_robustness.py
+++ b/tests/test_parser_robustness.py
@@ -1,0 +1,187 @@
+"""Robustness tests: comment false positives + per-language semantic resolution.
+
+These exercise the regex fallbacks (tree-sitter not required) and the
+configuration-aware resolvers added to raise every language parser's accuracy.
+"""
+from __future__ import annotations
+
+from archmap.core.parser import parse_project
+from archmap.core.parser._text import strip_comments
+from archmap.core.parser.csharp_parser import CSharpParser
+from archmap.core.parser.go_parser import _parse_go_replacements
+from archmap.core.parser.java_parser import JavaParser
+from archmap.core.parser.js_parser import JSParser
+from archmap.core.parser.php_parser import PHPParser
+
+
+def _deps(result: dict, file_id: str) -> set[str]:
+    entry = next(f for f in result["parsedFiles"] if f["id"] == file_id)
+    return {d["id"] for d in entry["dependencies"]}
+
+
+# ---------------------------------------------------------------------------
+# strip_comments utility
+# ---------------------------------------------------------------------------
+
+
+def test_strip_comments_preserves_strings_and_newlines() -> None:
+    src = 'const url = "http://x"; // import fake from "evil"\nimport real from "ok";'
+    cleaned = strip_comments(src, string_delims=('"', "'", "`"))
+    assert '"http://x"' in cleaned  # string preserved, // inside not a comment
+    assert "fake" not in cleaned  # comment content removed
+    assert cleaned.count("\n") == src.count("\n")  # line structure preserved
+
+
+def test_strip_comments_block() -> None:
+    src = "a /* import x from 'y' */ b"
+    assert "import" not in strip_comments(src)
+
+
+# ---------------------------------------------------------------------------
+# JS/JS false positives in comments
+# ---------------------------------------------------------------------------
+
+
+def test_js_ignores_imports_in_comments() -> None:
+    src = (
+        '// import ghost from "ghost-pkg";\n'
+        '/* require("block-ghost") */\n'
+        'import real from "real-pkg";\n'
+    )
+    imports = JSParser().parse(src)
+    assert imports == ["real-pkg"]
+
+
+# ---------------------------------------------------------------------------
+# C# aliases, global using, comment handling
+# ---------------------------------------------------------------------------
+
+
+def test_csharp_alias_captures_rhs_and_skips_comments() -> None:
+    src = (
+        "using System;\n"
+        "global using System.Linq;\n"
+        "using Json = Newtonsoft.Json;\n"
+        "// using Commented.Out;\n"
+    )
+    imports = CSharpParser().parse(src)
+    assert "System" in imports
+    assert "System.Linq" in imports
+    assert "Newtonsoft.Json" in imports  # alias RHS, not the alias name
+    assert "Json" not in imports
+    assert not any("Commented" in i for i in imports)
+
+
+# ---------------------------------------------------------------------------
+# Java inner classes + comment handling
+# ---------------------------------------------------------------------------
+
+
+def test_java_inner_class_resolves_to_outer_file() -> None:
+    files = {
+        "src/main/java/app/Main.java": (
+            "// import com.example.Ghost;\n"
+            "import com.example.Outer.Inner;\n"
+        ),
+        "com/example/Outer.java": "package com.example; class Outer {}\n",
+    }
+    result = parse_project(".", virtual_files=files)
+    deps = _deps(result, "src/main/java/app/Main.java")
+    assert "com/example/Outer.java" in deps
+    assert not any("Ghost" in d for d in deps)
+
+
+def test_java_comment_import_is_ignored() -> None:
+    imports = JavaParser().parse("// import com.x.Y;\nimport com.real.Z;\n")
+    assert imports == ["com.real.Z"]
+
+
+# ---------------------------------------------------------------------------
+# Go replace directives
+# ---------------------------------------------------------------------------
+
+
+def test_parse_go_replacements_local_only() -> None:
+    mod = (
+        "module example.com/app\n"
+        "replace example.com/old => ./internal/old\n"
+        "replace example.com/remote v1.2.3 => github.com/fork/remote v1.2.4\n"
+        "replace (\n"
+        "  example.com/grouped v1 => ../grouped\n"
+        ")\n"
+    )
+    rep = _parse_go_replacements(mod)
+    assert rep == {
+        "example.com/old": "./internal/old",
+        "example.com/grouped": "../grouped",
+    }
+
+
+def test_go_replace_resolves_to_local_file() -> None:
+    files = {
+        "go.mod": "module example.com/app\nreplace example.com/lib => ./lib\n",
+        "main.go": 'import "example.com/lib/util"\n',
+        "lib/util/util.go": "package util\n",
+    }
+    result = parse_project(".", virtual_files=files)
+    assert "lib/util/util.go" in _deps(result, "main.go")
+
+
+# ---------------------------------------------------------------------------
+# PHP composer PSR-4
+# ---------------------------------------------------------------------------
+
+
+def test_php_psr4_resolves_namespace_to_src() -> None:
+    files = {
+        "composer.json": '{"autoload": {"psr-4": {"App\\\\": "src/"}}}',
+        "index.php": "<?php\nuse App\\Models\\User;\n",
+        "src/Models/User.php": "<?php\nnamespace App\\Models;\nclass User {}\n",
+    }
+    result = parse_project(".", virtual_files=files)
+    assert "src/Models/User.php" in _deps(result, "index.php")
+
+
+def test_php_psr4_longest_prefix_wins() -> None:
+    files = {
+        "composer.json": (
+            '{"autoload": {"psr-4": '
+            '{"App\\\\": "src/", "App\\\\Admin\\\\": "admin/"}}}'
+        ),
+        "index.php": "<?php\nuse App\\Admin\\Dashboard;\n",
+        "admin/Dashboard.php": "<?php\nnamespace App\\Admin;\nclass Dashboard {}\n",
+    }
+    result = parse_project(".", virtual_files=files)
+    assert "admin/Dashboard.php" in _deps(result, "index.php")
+
+
+def test_php_comment_use_is_ignored() -> None:
+    imports = PHPParser().parse("<?php\n// use Ghost\\Thing;\nuse Real\\Thing;\n")
+    values = {e["value"] for e in imports}
+    assert "Real\\Thing" in values
+    assert not any("Ghost" in v for v in values)
+
+
+# ---------------------------------------------------------------------------
+# C/C++ include-dir suffix resolution + comment handling
+# ---------------------------------------------------------------------------
+
+
+def test_cpp_include_dir_suffix_resolution() -> None:
+    files = {
+        "src/app.cpp": '#include "mylib/widget.h"\n',
+        "include/mylib/widget.h": "// header\n",
+    }
+    result = parse_project(".", virtual_files=files)
+    assert "include/mylib/widget.h" in _deps(result, "src/app.cpp")
+
+
+def test_cpp_comment_include_is_ignored() -> None:
+    files = {
+        "a.c": '// #include "ghost.h"\n/* #include "block.h" */\n#include "real.h"\n',
+        "real.h": "int x;\n",
+    }
+    result = parse_project(".", virtual_files=files)
+    deps = _deps(result, "a.c")
+    assert "real.h" in deps
+    assert not any("ghost" in d or "block" in d for d in deps)

--- a/tests/test_tree_sitter_fallback.py
+++ b/tests/test_tree_sitter_fallback.py
@@ -1,0 +1,122 @@
+"""Tree-sitter orchestration: per-language availability + automatic fallback.
+
+The orchestration tests monkeypatch the engine internals so they run
+deterministically whether or not the optional tree-sitter grammars are
+installed. A second group of tests exercises the real grammars and is skipped
+when they are absent.
+"""
+from __future__ import annotations
+
+import pytest
+
+from archmap.core.parser import ts_engine
+from archmap.core.parser.csharp_parser import CSharpParser
+from archmap.core.parser.js_parser import JSParser
+
+
+class _FakeTree:
+    def __init__(self, has_error: bool) -> None:
+        self.root_node = type("Node", (), {"has_error": has_error})()
+
+
+# ---------------------------------------------------------------------------
+# Orchestration / fallback decision (deterministic, always run)
+# ---------------------------------------------------------------------------
+
+
+def test_try_extract_unknown_language_returns_none() -> None:
+    assert ts_engine.try_extract("cobol", "stuff") is None
+
+
+def test_try_extract_unavailable_grammar_returns_none(monkeypatch) -> None:
+    monkeypatch.setitem(ts_engine._EXTRACTORS, "fake", ("fakegrammar", lambda t, n: []))
+    monkeypatch.setattr(ts_engine, "_load_language", lambda name: None)
+    assert ts_engine.try_extract("fake", "x") is None
+
+
+def _wire_fake(monkeypatch, extractor, *, has_error: bool) -> None:
+    monkeypatch.setitem(ts_engine._EXTRACTORS, "fake", ("fakegrammar", extractor))
+    monkeypatch.setattr(ts_engine, "_load_language", lambda name: object())
+    monkeypatch.setattr(ts_engine, "_parse", lambda lang, src: _FakeTree(has_error))
+
+
+def test_try_extract_returns_none_when_extractor_raises(monkeypatch) -> None:
+    def boom(_tree, _name):
+        raise RuntimeError("grammar panic")
+
+    _wire_fake(monkeypatch, boom, has_error=False)
+    assert ts_extract_fake() is None
+
+
+def test_try_extract_falls_back_when_errored_and_empty(monkeypatch) -> None:
+    _wire_fake(monkeypatch, lambda t, n: [], has_error=True)
+    assert ts_extract_fake() is None
+
+
+def test_try_extract_trusts_clean_empty_parse(monkeypatch) -> None:
+    _wire_fake(monkeypatch, lambda t, n: [], has_error=False)
+    assert ts_extract_fake() == []
+
+
+def test_try_extract_keeps_results_despite_minor_errors(monkeypatch) -> None:
+    _wire_fake(monkeypatch, lambda t, n: ["mod"], has_error=True)
+    assert ts_extract_fake() == ["mod"]
+
+
+def ts_extract_fake():
+    return ts_engine.try_extract("fake", "source")
+
+
+# ---------------------------------------------------------------------------
+# Parser-level automatic fallback to regex
+# ---------------------------------------------------------------------------
+
+
+def test_jsparser_uses_regex_when_tree_sitter_declines(monkeypatch) -> None:
+    # Simulate tree-sitter being unavailable/unreliable for this file.
+    monkeypatch.setattr(ts_engine, "try_extract", lambda lang, src: None)
+    imports = JSParser().parse('// import ghost from "g";\nimport real from "real-pkg";\n')
+    assert imports == ["real-pkg"]
+
+
+def test_csharp_uses_regex_when_tree_sitter_declines(monkeypatch) -> None:
+    monkeypatch.setattr(ts_engine, "try_extract", lambda lang, src: None)
+    imports = CSharpParser().parse("using Json = Newtonsoft.Json;\nusing System;\n")
+    assert "Newtonsoft.Json" in imports
+    assert "System" in imports
+    assert "Json" not in imports
+
+
+# ---------------------------------------------------------------------------
+# Real grammars (skipped when not installed)
+# ---------------------------------------------------------------------------
+
+requires_ts = pytest.mark.skipif(
+    not ts_engine.HAS_TREE_SITTER, reason="tree-sitter grammars not installed"
+)
+
+
+@requires_ts
+def test_language_available_reports_per_language() -> None:
+    # At least one grammar must be available if HAS_TREE_SITTER is True.
+    assert any(ts_engine.language_available(name) for name in ts_engine._GRAMMAR_LOADERS)
+
+
+@requires_ts
+def test_csharp_structured_alias_via_tree_sitter() -> None:
+    src = (
+        "using System;\n"
+        "global using System.Linq;\n"
+        "using Json = Newtonsoft.Json;\n"
+        "using static System.Math;\n"
+    )
+    imports = ts_engine.extract_csharp_imports(src)
+    assert imports == ["Newtonsoft.Json", "System", "System.Linq", "System.Math"]
+
+
+@requires_ts
+def test_try_extract_real_fallback_on_garbage() -> None:
+    # Heavily broken C# that tree-sitter cannot parse into using-directives:
+    # try_extract should decline (None) so the caller uses regex.
+    result = ts_engine.try_extract("csharp", "@@@ not valid using at all %%%")
+    assert result is None or result == []

--- a/tests/test_v1_0_1_fixes.py
+++ b/tests/test_v1_0_1_fixes.py
@@ -1,0 +1,255 @@
+"""Regression tests for the v1.0.1 correctness, performance and security fixes."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from archmap.cli import server as cli_server
+from archmap.core.advisor.llm_advisor import _build_prompt
+from archmap.core.analyzer.impact_analyzer import build_dependents_map, calculate_impact
+from archmap.core.parser import parse_project
+from archmap.exporters.mermaid_exporter import _to_mermaid_label
+from test_cli_server import StubState, request_json, run_handler_server
+
+# ---------------------------------------------------------------------------
+# tsconfig path-alias resolution (product feature)
+# ---------------------------------------------------------------------------
+
+
+def _deps(result: dict, file_id: str) -> set[str]:
+    entry = next(f for f in result["parsedFiles"] if f["id"] == file_id)
+    return {d["id"] for d in entry["dependencies"]}
+
+
+def test_tsconfig_paths_alias_resolves_to_internal_file() -> None:
+    files = {
+        "tsconfig.json": (
+            '{\n'
+            '  // path aliases\n'
+            '  "compilerOptions": {\n'
+            '    "baseUrl": ".",\n'
+            '    "paths": { "@app/*": ["src/*"] },\n'
+            '  }\n'
+            '}\n'
+        ),
+        "src/app.ts": 'import { thing } from "@app/utils/helper";\n',
+        "src/utils/helper.ts": "export const thing = 1;\n",
+    }
+    result = parse_project(".", virtual_files=files)
+    deps = _deps(result, "src/app.ts")
+    assert "src/utils/helper.ts" in deps
+    assert "pkg:@app/utils/helper" not in deps
+
+
+def test_tsconfig_baseurl_resolves_bare_specifier() -> None:
+    files = {
+        "tsconfig.json": '{"compilerOptions": {"baseUrl": "src"}}',
+        "src/app.ts": 'import x from "utils/helper";\n',
+        "src/utils/helper.ts": "export default 1;\n",
+    }
+    result = parse_project(".", virtual_files=files)
+    assert "src/utils/helper.ts" in _deps(result, "src/app.ts")
+
+
+def test_without_tsconfig_bare_specifier_is_a_package() -> None:
+    files = {"src/app.ts": 'import x from "@app/utils/helper";\n'}
+    result = parse_project(".", virtual_files=files)
+    # Scoped specifier degrades to the npm-style scoped package name.
+    assert "pkg:@app/utils" in _deps(result, "src/app.ts")
+    assert not any(d.startswith("src/") for d in _deps(result, "src/app.ts"))
+
+
+def test_malformed_tsconfig_falls_back_gracefully() -> None:
+    files = {
+        "tsconfig.json": "{ this is not valid json",
+        "src/app.ts": 'import x from "@app/x";\n',
+    }
+    result = parse_project(".", virtual_files=files)
+    # No crash; bare specifier degrades to a package node.
+    assert "pkg:@app/x" in _deps(result, "src/app.ts")
+
+
+# ---------------------------------------------------------------------------
+# Impact analysis performance fix (shared dependents map)
+# ---------------------------------------------------------------------------
+
+
+def test_impact_with_shared_map_matches_standalone() -> None:
+    edges = [
+        {"source": "a.py", "target": "b.py"},
+        {"source": "b.py", "target": "c.py"},
+        {"source": "d.py", "target": "c.py"},
+    ]
+    shared = build_dependents_map(edges)
+    for node in ("a.py", "b.py", "c.py", "d.py"):
+        assert calculate_impact(node, edges, shared) == calculate_impact(node, edges)
+
+
+def test_impact_transitive_dependents() -> None:
+    edges = [
+        {"source": "a.py", "target": "b.py"},
+        {"source": "b.py", "target": "c.py"},
+    ]
+    impact = calculate_impact("c.py", edges)
+    assert impact["impactedFiles"] == ["a.py", "b.py"]
+    assert impact["impactCount"] == 2
+
+
+def test_impact_risk_levels() -> None:
+    # 6 dependents -> warning, 11 dependents -> critical
+    warning_edges = [{"source": f"f{i}.py", "target": "hub.py"} for i in range(6)]
+    assert calculate_impact("hub.py", warning_edges)["risk"] == "warning"
+
+    critical_edges = [{"source": f"f{i}.py", "target": "hub.py"} for i in range(11)]
+    assert calculate_impact("hub.py", critical_edges)["risk"] == "critical"
+
+    assert calculate_impact("hub.py", [])["risk"] == "low"
+
+
+def test_tsconfig_exact_alias_without_wildcard() -> None:
+    files = {
+        "tsconfig.json": (
+            '{"compilerOptions": {"paths": {"@config": ["src/config/index.ts"]}}}'
+        ),
+        "src/main.ts": 'import cfg from "@config";\n',
+        "src/config/index.ts": "export default {};\n",
+    }
+    result = parse_project(".", virtual_files=files)
+    assert "src/config/index.ts" in _deps(result, "src/main.ts")
+
+
+def test_jsconfig_is_used_when_tsconfig_absent() -> None:
+    files = {
+        "jsconfig.json": '{"compilerOptions": {"baseUrl": "src"}}',
+        "src/app.js": 'import x from "lib/util";\n',
+        "src/lib/util.js": "module.exports = 1;\n",
+    }
+    result = parse_project(".", virtual_files=files)
+    assert "src/lib/util.js" in _deps(result, "src/app.js")
+
+
+# ---------------------------------------------------------------------------
+# Mermaid label escaping
+# ---------------------------------------------------------------------------
+
+
+def test_mermaid_label_escapes_breaking_characters() -> None:
+    label = _to_mermaid_label('a[b]{c}\nd"e<f>')
+    assert "\n" not in label
+    assert "[" not in label and "]" not in label
+    assert "{" not in label and "}" not in label
+    assert "<" not in label and ">" not in label
+    assert label.startswith('"') and label.endswith('"')
+
+
+# ---------------------------------------------------------------------------
+# Advisor field-name bug (layer violations rendered correctly)
+# ---------------------------------------------------------------------------
+
+
+def test_advisor_prompt_renders_layer_violations() -> None:
+    report = {
+        "metrics": {},
+        "architecture": {},
+        "cycles": [],
+        "risks": {
+            "layer_violations": [
+                {
+                    "source": "src/utils/log.py",
+                    "target": "src/cli/main.py",
+                    "sourceLayer": "utils",
+                    "targetLayer": "cli",
+                }
+            ]
+        },
+    }
+    prompt = _build_prompt(report)
+    assert "utils -> cli: src/utils/log.py" in prompt
+    assert "None -> None" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Security: sensitive POST endpoints gated to loopback
+# ---------------------------------------------------------------------------
+
+
+def _non_local_handler(tmp_path: Path):
+    static_dir = tmp_path / "static"
+    static_dir.mkdir(exist_ok=True)
+    state = StubState(tmp_path / "project")
+    handler = cli_server.build_http_handler(state, static_dir)
+    handler._is_local_request = lambda self: False  # type: ignore[method-assign]
+    return handler, state
+
+
+def test_set_project_blocked_for_non_local_request(tmp_path) -> None:
+    handler, state = _non_local_handler(tmp_path)
+    other = tmp_path / "other"
+    other.mkdir()
+    with run_handler_server(handler) as base_url:
+        status, payload = request_json(
+            f"{base_url}/api/project", method="POST", payload={"path": str(other)}
+        )
+    assert status == 403
+    assert payload == {"status": "error", "message": "only available on localhost"}
+    assert state.path == (tmp_path / "project").resolve()
+
+
+def test_reanalyze_blocked_for_non_local_request(tmp_path) -> None:
+    handler, state = _non_local_handler(tmp_path)
+    with run_handler_server(handler) as base_url:
+        status, _ = request_json(f"{base_url}/api/reanalyze", method="POST")
+    assert status == 403
+    assert state.reanalyze_calls == 0
+
+
+def test_advise_blocked_for_non_local_request(tmp_path) -> None:
+    handler, _ = _non_local_handler(tmp_path)
+    with run_handler_server(handler) as base_url:
+        status, _ = request_json(
+            f"{base_url}/api/advise", method="POST", payload={"provider": "ollama"}
+        )
+    assert status == 403
+
+
+def test_advise_rejects_non_http_base_url(tmp_path) -> None:
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    state = StubState(tmp_path / "project")
+    state.report = {"architecture": {}, "metrics": {}, "risks": {}, "cycles": []}
+    handler = cli_server.build_http_handler(state, static_dir)
+    with run_handler_server(handler) as base_url:
+        status, payload = request_json(
+            f"{base_url}/api/advise",
+            method="POST",
+            payload={"provider": "custom", "base_url": "file:///etc/passwd"},
+        )
+    assert status == 400
+    assert "base_url" in payload["message"]
+
+
+# ---------------------------------------------------------------------------
+# Loopback helper + base_url validator
+# ---------------------------------------------------------------------------
+
+
+def test_is_loopback_host() -> None:
+    assert cli_server._is_loopback_host("127.0.0.1")
+    assert cli_server._is_loopback_host("localhost")
+    assert cli_server._is_loopback_host("::1")
+    assert not cli_server._is_loopback_host("0.0.0.0")
+    assert not cli_server._is_loopback_host("192.168.1.5")
+
+
+def test_is_safe_base_url() -> None:
+    assert cli_server._is_safe_base_url("http://localhost:11434")
+    assert cli_server._is_safe_base_url("https://api.openai.com")
+    assert not cli_server._is_safe_base_url("file:///etc/passwd")
+    assert not cli_server._is_safe_base_url("gopher://evil")
+    assert not cli_server._is_safe_base_url("")
+    assert not cli_server._is_safe_base_url("not-a-url")
+
+
+def test_default_host_is_loopback() -> None:
+    from archmap.cli.defaults import DEFAULT_HOST
+
+    assert DEFAULT_HOST == "127.0.0.1"


### PR DESCRIPTION
## Overview

This PR consolidates three patch releases plus a documentation refresh, all
backward-compatible with 1.0.0 (no public API changes). It originated from a
full engineering audit and addresses the highest-severity findings: a server
security gap, an O(V·E) performance hotspot, parser accuracy across every
language, and a from-scratch rework of the tree-sitter engine into a resilient
primary parser.

**42 files changed · +2498 / −356 · 4 commits**
Validated on every step: `ruff` clean, `mypy` clean, suite green **with** tree-sitter
(584 tests, 86.9% coverage) **and without** it (557 tests, 85.1% coverage).

---

## v1.0.1 — Security, performance & correctness hardening

**Security (the critical audit finding)**
- `serve` now binds to `127.0.0.1` by default (was `0.0.0.0`); a warning is
  printed when you explicitly expose it with `--host`.
- All state-changing / local endpoints are gated to loopback: `/api/project`
  (switch analyzed directory), `/api/reanalyze`, and `/api/advise` previously
  had **no** localhost check while the server bound to `0.0.0.0`, allowing a host
  on the same network to repoint the analyzer at any directory (and read its
  structure via `/api/graph`) or trigger outbound LLM calls (SSRF).
- `/api/advise` validates `base_url` (only `http`/`https`), blocking `file://`
  and other schemes.

**Performance**
- Whole-graph impact analysis reduced from **O(V·E) to O(V+E)**: the backward
  adjacency map is built once and shared (`impact_analyzer.build_dependents_map`),
  and the BFS uses a `deque` instead of `list.pop(0)`.

**Bug fixes**
- LLM advisor read non-existent `fromLayer`/`toLayer` keys and emitted
  `None -> None`; it now reads the real `sourceLayer`/`targetLayer`/`source` fields.
- Mermaid label escaping for `\n`, `[` `]`, `{` `}`, `<` `>`, `"` and `\`.

**Feature**
- tsconfig / jsconfig `baseUrl` + `paths` alias resolution for JS/TS imports
  (e.g. `@app/*` → `src/*`), raising the resolution rate on real TS projects.

**Quality**
- Coverage gate enforced in CI (`--cov-fail-under=85`).
- Dockerfile pinned to `python:3.13-slim` (was the unreleased `3.14-slim`).

---

## v1.0.2 — Parser accuracy across all languages

- **Comment-aware regex fallbacks** — a shared, string-aware `strip_comments`
  pass removes `//`, `/* */` (and `#` for PHP) before import matching, so
  import-like text in comments no longer creates phantom dependencies (JS/TS,
  Java, C#, PHP, C/C++). String literals and line structure are preserved.
- **Go** — local `replace` directives in `go.mod` resolve to the replaced directory.
- **PHP** — `composer.json` PSR-4 autoload resolution (longest prefix wins),
  replacing the fragile suffix-matching heuristic.
- **C#** — `using Alias = Real.Namespace;` now extracts the right-hand namespace
  (previously captured the alias name); `global using` recognized.
- **Java** — inner-class resolution (`com.example.Outer.Inner` → `Outer.java`).
- **C/C++** — include-dir suffix resolution for the common `-I` layout.

---

## v1.0.3 — Tree-sitter as a resilient primary parser

Reworks the optional `[tree-sitter]` engine from an all-or-nothing global switch
into a robust primary parser with automatic per-file fallback.

- **Per-language grammar availability** — each grammar loads independently; one
  missing/broken grammar no longer disables tree-sitter for the others
  (`ts_engine.language_available`).
- **Automatic per-file fallback (`ts_engine.try_extract`)** — returns the
  structured AST result, or `None` to request the regex fallback when tree-sitter
  cannot be trusted for a file (grammar unavailable, parse/query raised, or the
  parse has errors and recovered no imports). Previously a file that made
  tree-sitter raise was **dropped from the graph entirely**.
- **Structured C# extraction** from typed AST nodes — aliases, `global using`,
  `using static` — so the AST and regex paths agree.
- **CI now tests both paths** — a dedicated `tree-sitter` job runs the suite with
  the grammars installed (the AST path was previously untested in CI), while the
  `quality` job keeps covering the regex fallback.

---

## Documentation & GitHub Pages

**Content corrections**
- `index.md`: version badge 1.0.0 → 1.0.3, "What's new in 1.0.x".
- `cli/serve.md`: correct default host, full live-endpoint table with loopback
  scope, new **Security** section.
- `architecture.md`: complete 9-language parser table, tree-sitter-as-primary,
  configuration-aware resolution table.
- `api.md`: documents badge/project/SSE endpoints and the loopback security model.
- `installation.md`: fixed package name (`KG-ARCHMAP`), added the `[tree-sitter]`
  extra and Docker instructions.
- mkdocs nav: added the previously-orphaned `mcp` and `temporal` CLI pages.

**Visual refresh** — branded typography, grid cards, tables, buttons, hero and
footer in `extra.css`; system/light/dark palette, sticky tabs, footer nav, and
Inter + JetBrains Mono fonts in `mkdocs.yml`. Verified with `mkdocs build --strict`.

---

## Testing

New regression suites: `tests/test_v1_0_1_fixes.py`, `tests/test_parser_robustness.py`,
`tests/test_tree_sitter_fallback.py`. The tree-sitter orchestration tests are
deterministic (monkeypatched) so they run with or without the grammars installed;
a `skipif` group exercises the real grammars when present.

| Configuration | Result |
|---|---|
| With tree-sitter | 584 passed, 86.9% coverage |
| Without tree-sitter (regex) | 557 passed, 24 skipped, 85.1% coverage |
| ruff / mypy | clean |

https://claude.ai/code/session_01DmRAq95TpbuQpVE6YbGLPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmRAq95TpbuQpVE6YbGLPJ)_